### PR TITLE
Lightning parsing mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bech32"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Clark Moody"]
 repository = "https://github.com/rust-bitcoin/rust-bech32"
 description = "Encodes and decodes the Bech32 format"


### PR DESCRIPTION
Add a `from_str_lenient` method which doesn't enforce the 90 character limit to support the [BOLT 11](https://github.com/lightningnetwork/lightning-rfc/blob/master/11-payment-encoding.md#requirements) use case.

A downside of this approach is that the `Bech32` 'contract' doesn't contain the max char limit at all anymore, but that seems preferable to building a `RawBech32` struct without the limitation and the `Bech32`  struct as a mere wrapper to enforce the original contract.