### PR TITLE
Fix missing range checks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bech32"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["Clark Moody"]
 repository = "https://github.com/rust-bitcoin/rust-bech32"
 description = "Encodes and decodes the Bech32 format"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -551,6 +551,8 @@ mod tests {
                 Error::InvalidLength),
             ("x1b4n0q5v",
                 Error::InvalidChar('b')),
+            ("ABC1DEFGOH",
+                Error::InvalidChar('O')),
             ("li1dgmt3",
                 Error::InvalidLength),
             ("de1lg7wt\u{ff}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,8 +63,9 @@
 #![deny(unused_mut)]
 
 use std::{error, fmt};
-use std::str::FromStr;
+use std::ascii::AsciiExt;
 use std::fmt::{Display, Formatter};
+use std::str::FromStr;
 
 /// Integer in the range `0..32`
 #[derive(PartialEq, Eq, Debug, Copy, Clone, Default, PartialOrd, Ord, Hash)]
@@ -249,9 +250,9 @@ impl Bech32 {
                 return Err(Error::InvalidChar(c))
             }
 
-            if c.is_ascii_lowercase() {
+            if c.is_lowercase() {
                 has_lower = true;
-            } else if c.is_ascii_uppercase() {
+            } else if c.is_uppercase() {
                 has_upper = true;
             }
 
@@ -540,8 +541,8 @@ mod tests {
         let pairs: Vec<(&str, Error)> = vec!(
             (" 1nwldj5",
                 Error::InvalidChar(' ')),
-            ("\x7f1axkwrx",
-                Error::InvalidChar(0x7f as char)),
+            ("abc1\u{2192}axkwrx",
+                Error::InvalidChar('\u{2192}')),
             ("an84characterslonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1569pvx",
                 Error::InvalidLength),
             ("pzry9x0s0muk",
@@ -553,7 +554,7 @@ mod tests {
             ("li1dgmt3",
                 Error::InvalidLength),
             ("de1lg7wt\u{ff}",
-                Error::InvalidChar(0xc3 as char)), // ASCII 0xff -> \uC3BF in UTF-8
+                Error::InvalidChar('\u{ff}')),
         );
         for p in pairs {
             let (s, expected_error) = p;
@@ -562,7 +563,7 @@ mod tests {
                 println!("{:?}", dec_result.unwrap());
                 panic!("Should be invalid: {:?}", s);
             }
-            assert_eq!(dec_result.unwrap_err(), expected_error);
+            assert_eq!(dec_result.unwrap_err(), expected_error, "testing input '{}'", s);
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -650,4 +650,24 @@ mod tests {
         use ToBase32;
         assert_eq!([0xffu8].to_base32(), [0x1f, 0x1c].check_base32().unwrap());
     }
+
+    #[test]
+    fn reverse_charset() {
+        use std::ascii::AsciiExt;
+        use ::CHARSET_REV;
+
+        fn get_char_value(c: char) -> i8 {
+            let charset = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";
+            match charset.find(c.to_ascii_lowercase()) {
+                Some(x) => x as i8,
+                None => -1,
+            }
+        }
+
+        let expected_rev_charset = (0u8..128).map(|i| {
+            get_char_value(i as char)
+        }).collect::<Vec<_>>();
+
+        assert_eq!(&(CHARSET_REV[..]), expected_rev_charset.as_slice());
+    }
 }


### PR DESCRIPTION
Fixes #22. 

## TODO:

- [x] rewrite `from_str_lenient` to catch all bad characters
- [x] adapt tests that use `Error::InvalidChar` since its signature was updated
- [x] validate that all bad characters are `-1` in `CHARSET_REV`
- [x] write tests to show the bug is fixed
- [x] have a look at the checks for mixed case, they seem overly complicated