### PR TITLE
Suppress warnings caused by AsciiExt use statement

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,9 @@
 #![deny(unused_mut)]
 
 use std::{error, fmt};
+
+// AsciiExt is needed for Rust 1.14 but not for newer versions
+#[allow(unused_imports, deprecated)]
 use std::ascii::AsciiExt;
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;


### PR DESCRIPTION
To support Rust 1.14.0 the trait `AsciiExt` is needed, but it's deprecated and unused in newer version. This is a follow up to #24 which was caused by #23.