### PR TITLE
Treat warnings as errors when running tests on travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,7 @@ rust:
   - nightly
   - 1.14.0  # shipping debian version 2018 03
 cache: cargo
+
+script:
+  - cargo build --verbose --features strict
+  - cargo test --verbose --features strict

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,8 @@ keywords = ["base32", "encoding", "bech32"]
 categories = ["encoding"]
 license = "MIT"
 
+[features]
+# Only for CI to make all warnings errors, do not activate otherwise (may break forward compatibility)
+strict = []
+
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,8 @@
 #![deny(non_snake_case)]
 #![deny(unused_mut)]
 
+#![cfg_attr(feature = "strict", deny(warnings))]
+
 use std::{error, fmt};
 
 // AsciiExt is needed for Rust 1.14 but not for newer versions
@@ -658,6 +660,8 @@ mod tests {
 
     #[test]
     fn reverse_charset() {
+        // AsciiExt is needed for Rust 1.14 but not for newer versions
+        #[allow(unused_imports, deprecated)]
         use std::ascii::AsciiExt;
         use ::CHARSET_REV;
 


### PR DESCRIPTION
To avoid regressions like #24 I'd like to treat all warnings like errors when running our tests on travis.