### PR TITLE
WIP: Enable writing to an existing vector in ToBase32

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@ pub trait FromBase32: Sized {
 pub trait ToBase32 {
     /// Convert `Self` to base32 slice
     fn to_base32(&self) -> Vec<u5> {
-        let mut buff = Vec::new();
+        let mut buff = Vec::with_capacity(self.serialized_length());
         self.write_base32(&mut buff);
         buff
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,12 @@ pub trait ToBase32 {
 
     /// Convert `Self` to bech32 and append the result to a supplied, mutable buffer
     fn write_base32(&self, buffer: &mut Vec<u5>);
+
+    /// Calculates the length of the serialized data
+    ///
+    /// This can be used in combination with `write_base32` to avoid allocations and is useful
+    /// for serializing dynamically sized data structures.
+    fn serialized_length(&self) -> usize;
 }
 
 /// A trait to convert between u8 arrays and u5 arrays without changing the content of the elements,
@@ -177,6 +183,15 @@ impl<T: AsRef<[u8]>> ToBase32 for T {
         ).check_base32().expect(
             "after conversion all elements are in range"
         ))
+    }
+
+    fn serialized_length(&self) -> usize {
+        let bits = self.as_ref().len() * 8;
+        if bits % 5 == 0 {
+            bits / 5
+        } else {
+            bits / 5 + 1
+        }
     }
 }
 
@@ -690,5 +705,15 @@ mod tests {
         }).collect::<Vec<_>>();
 
         assert_eq!(&(CHARSET_REV[..]), expected_rev_charset.as_slice());
+    }
+
+    #[test]
+    fn test_to_base32_len() {
+        use ::ToBase32;
+
+        for len in 0..128 {
+            let data = vec![0xff; len];
+            assert_eq!(data.to_base32().len(), data.serialized_length())
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,9 +88,16 @@ pub trait FromBase32: Sized {
 }
 
 /// A trait for converting a value to a type `T` that represents a `u5` slice.
-pub trait ToBase32<T: AsRef<[u5]>> {
+pub trait ToBase32 {
     /// Convert `Self` to base32 slice
-    fn to_base32(&self) -> T;
+    fn to_base32(&self) -> Vec<u5> {
+        let mut buff = Vec::new();
+        self.write_base32(&mut buff);
+        buff
+    }
+
+    /// Convert `Self` to bech32 and append the result to a supplied, mutable buffer
+    fn write_base32(&self, buffer: &mut Vec<u5>);
 }
 
 /// A trait to convert between u8 arrays and u5 arrays without changing the content of the elements,
@@ -163,14 +170,13 @@ impl FromBase32 for Vec<u8> {
     }
 }
 
-impl<T: AsRef<[u8]>> ToBase32<Vec<u5>> for T {
-    /// Convert base256 to base32, adds padding if necessary
-    fn to_base32(&self) -> Vec<u5> {
-        convert_bits(self.as_ref(), 8, 5, true).expect(
+impl<T: AsRef<[u8]>> ToBase32 for T {
+    fn write_base32(&self, buffer: &mut Vec<u5>) {
+        buffer.extend_from_slice(&convert_bits(self.as_ref(), 8, 5, true).expect(
             "both error conditions are impossible (InvalidPadding, InvalidData)"
         ).check_base32().expect(
             "after conversion all elements are in range"
-        )
+        ))
     }
 }
 
@@ -469,6 +475,8 @@ impl error::Error for Error {
 /// let base5 = convert_bits(&[0xff], 8, 5, true);
 /// assert_eq!(base5.unwrap(), vec![0x1f, 0x1c]);
 /// ```
+///
+// TODO: use mut buffer
 pub fn convert_bits<T>(data: &[T], from: u32, to: u32, pad: bool) -> Result<Vec<u8>, Error>
     where T: Into<u8> + Copy
 {


### PR DESCRIPTION
This makes recursive serialization in `lightning-invoice` much more efficient.