### PR TITLE
Allocationless ecoding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: rust
 rust:
   - stable
   - nightly
-  - 1.14.0  # shipping debian version 2018 03
+  - 1.22.0  # project wide min version
 cache: cargo
 
 script:

--- a/README.md
+++ b/README.md
@@ -1,32 +1,8 @@
 # Bech32 Rust
+[![Docs.rs badge](https://docs.rs/bech32/badge.svg)](https://docs.rs/bech32/)
+[![Build Status](https://travis-ci.org/rust-bitcoin/rust-bech32.svg?branch=master)](https://travis-ci.org/rust-bitcoin/rust-bech32)
 
 Rust implementation of the Bech32 encoding format described in [BIP-0173](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki).
+You can find some usage examples in the [documentation](https://docs.rs/bech32/).
 
 Bitcoin-specific address encoding is handled by the `bitcoin-bech32` crate.
-
-## Examples
-```rust
-use bech32::Bech32;
-
-let b = Bech32::new_check_data("bech32".into(), vec![0x00, 0x01, 0x02]).unwrap();
-let encoded = b.to_string();
-assert_eq!(encoded, "bech321qpz4nc4pe".to_string());
-
-let c = encoded.parse::<Bech32>();
-assert_eq!(b, c.unwrap());
-```
-
-If the data is already range-checked the `Bech32::new` function can be used which will never
-return `Err(Error::InvalidData)`.
-
-```rust
-use bech32::{Bech32, u5, ToBase32};
-
-// converts base256 data to base32 and adds padding if needed
-let checked_data: Vec<u5> = [0xb4, 0xff, 0xa5].to_base32();
-
-let b = Bech32::new("bech32".into(), checked_data).expect("hrp is not empty");
-let encoded = b.to_string();
-
-assert_eq!(encoded, "bech321knl623tk6v7".to_string());
-```

--- a/fuzz/fuzz_targets/decode_rnd.rs
+++ b/fuzz/fuzz_targets/decode_rnd.rs
@@ -4,13 +4,13 @@ use std::str::FromStr;
 
 fn do_test(data: &[u8]) {
     let data_str = String::from_utf8_lossy(data);
-    let decoded = data_str.parse::<bech32::Bech32>();
+    let decoded = bech32::decode(&data_str);
     let b32 = match decoded {
         Ok(b32) => b32,
         Err(_) => return,
     };
 
-    assert_eq!(b32.to_string(), data_str);
+    assert_eq!(bech32::encode(&b32.0, b32.1).unwrap(), data_str);
 }
 
 #[cfg(feature = "afl")]

--- a/fuzz/fuzz_targets/encode_decode.rs
+++ b/fuzz/fuzz_targets/encode_decode.rs
@@ -13,18 +13,18 @@ fn do_test(data: &[u8]) {
         return;
     }
 
-    let hrp = String::from_utf8_lossy(&data[1..hrp_end]).to_string();
+    let hrp = String::from_utf8_lossy(&data[1..hrp_end]).to_lowercase().to_string();
 
     let dp = data[hrp_end..]
         .iter()
         .map(|b| bech32::u5::try_from_u8(b % 32).unwrap())
         .collect::<Vec<_>>();
 
-    if let Ok(data_str) = bech32::Bech32::new(hrp, dp).map(|b32| b32.to_string()) {
-        let decoded = data_str.parse::<bech32::Bech32>();
+    if let Ok(data_str) = bech32::encode(&hrp, &dp).map(|b32| b32.to_string()) {
+        let decoded = bech32::decode(&data_str);
         let b32 = decoded.expect("should be able to decode own encoding");
 
-        assert_eq!(b32.to_string(), data_str);
+        assert_eq!(bech32::encode(&b32.0, &b32.1).unwrap(), data_str);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,10 @@
 //! ```
 //!
 
+// Allow trait objects without dyn on nightly and make 1.22 ignore the unknown lint
+#![allow(unknown_lints)]
+#![allow(bare_trait_objects)]
+
 #![deny(missing_docs)]
 #![deny(non_upper_case_globals)]
 #![deny(non_camel_case_types)]


### PR DESCRIPTION
Builds on top of and closes #34 and adds a `Bech32Writer` struct that allows allocationless encoding to an underlying `std::fmt::Writer`.

- [x] ~fuzz `[u8]` -> `[u5]` encoding~ is covered by current (adapted) fuzz tests
- [x] remove redundant encoding code
- [x] fix rust 1.22 compatibility