### PR TITLE
Fix Nightly and Version 0.7.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bech32"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Clark Moody"]
 repository = "https://github.com/rust-bitcoin/rust-bech32"
 description = "Encodes and decodes the Bech32 format"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -751,7 +751,7 @@ mod tests {
             let result = catch_unwind(|| {
                 let _ = convert_bits(&[0], from, to, true);
             });
-            take_hook();
+            let _ = take_hook();
             assert!(result.is_err());
         }
     }


### PR DESCRIPTION
Consumes the output of `take_hook`, suppressing the warning.

Resolves #38 