### PR TITLE
Add no_std support for crates using compiler versions >1.36

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,13 @@ language: rust
 rust:
   - stable
   - nightly
-  - 1.22.0  # project wide min version
+  - 1.36.0  # project wide min version
 cache: cargo
 
 script:
+  - cargo build --verbose --no-default-features --features strict
   - cargo build --verbose --features strict
+  - cargo test --verbose --no-default-features --features strict
   - cargo test --verbose --features strict
 
 jobs:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ categories = ["encoding"]
 license = "MIT"
 
 [features]
+default = ["std"]
+std = []
 # Only for CI to make all warnings errors, do not activate otherwise (may break forward compatibility)
 strict = []
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,6 @@ assert_eq!(Vec::<u8>::from_base32(&data).unwrap(), vec![0x00, 0x01, 0x02]);
 ```
 "
 )]
-
 // Allow trait objects without dyn on nightly and make 1.22 ignore the unknown lint
 #![allow(unknown_lints)]
 #![allow(bare_trait_objects)]
@@ -54,8 +53,8 @@ assert_eq!(Vec::<u8>::from_base32(&data).unwrap(), vec![0x00, 0x01, 0x02]);
 #![deny(non_snake_case)]
 #![deny(unused_mut)]
 #![cfg_attr(feature = "strict", deny(warnings))]
-
 #![cfg_attr(not(feature = "std"), no_std)]
+
 #[cfg(not(feature = "std"))]
 #[allow(unused_imports)]
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,9 @@
 //!
 //! The original description in [BIP-0173](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki) has more details.
 //!
-#![cfg_attr(feature = "std", doc = "
+#![cfg_attr(
+    feature = "std",
+    doc = "
 # Examples
 
 ```
@@ -40,7 +42,8 @@ let (hrp, data) = bech32::decode(&encoded).unwrap();
 assert_eq!(hrp, \"bech32\");
 assert_eq!(Vec::<u8>::from_base32(&data).unwrap(), vec![0x00, 0x01, 0x02]);
 ```
-")]
+"
+)]
 
 // Allow trait objects without dyn on nightly and make 1.22 ignore the unknown lint
 #![allow(unknown_lints)]
@@ -63,7 +66,7 @@ extern crate alloc as std;
 // but that is an unstable feature at the time of writing
 // https://github.com/rust-lang/rust/issues/58935
 #[cfg(not(feature = "std"))]
-use std::{vec::Vec, string::String};
+use std::{string::String, vec::Vec};
 
 use std::borrow::Cow;
 use std::fmt;
@@ -620,7 +623,9 @@ impl std::error::Error for Error {
 /// Function will panic if attempting to convert `from` or `to` a bit size that
 /// is 0 or larger than 8 bits.
 ///
-#[cfg_attr(feature = "std", doc = "
+#[cfg_attr(
+    feature = "std",
+    doc = "
 # Examples
 
 ```rust
@@ -634,7 +639,8 @@ let base5 = convert_bits(&[0xff], 8, 5, true);
 assert_eq!(base5.unwrap(), vec![0x1f, 0x1c]);
 # }
 ```
-")]
+"
+)]
 pub fn convert_bits<T>(data: &[T], from: u32, to: u32, pad: bool) -> Result<Vec<u8>, Error>
 where
     T: Into<u8> + Copy,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@ assert_eq!(Vec::<u8>::from_base32(&data).unwrap(), vec![0x00, 0x01, 0x02]);
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #[cfg(not(feature = "std"))]
+#[allow(unused_imports)]
 #[macro_use]
 extern crate alloc as std;
 


### PR DESCRIPTION
This PR raises the minimum supported compiler version to 1.36 which allows us to import the [alloc built-in crate](https://doc.rust-lang.org/alloc/) and make only the minimum set of changes required to the codebase and API.

The only change to the public API is that crates which disable the default set of features (which enables `no_std`) will not observe the following implementation:
```rust
 impl std::error::Error for Error { ... }
```
And while running the test suite, the doctests and test called `convert_bits_invalid_bit_size` will not run in `no_std` mode.

Related to issue #45 that tried adding support without changing the minimum supported compiler version.