### PR TITLE
Derive all traits for error; bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bech32"
-version = "0.7.2"
+version = "0.7.3"
 authors = ["Clark Moody"]
 repository = "https://github.com/rust-bitcoin/rust-bech32"
 description = "Encodes and decodes the Bech32 format"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -553,7 +553,7 @@ const GEN: [u32; 5] = [
 ];
 
 /// Error types for Bech32 encoding / decoding
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub enum Error {
     /// String does not contain the separator character
     MissingSeparator,


### PR DESCRIPTION
This is required for an ongoing effort to improve rust-bitcoin error system