### PR TITLE
Implement From<u5> for u8

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,9 +99,9 @@ impl u5 {
     }
 }
 
-impl Into<u8> for u5 {
-    fn into(self) -> u8 {
-        self.0
+impl From<u5> for u8 {
+    fn from(v: u5) -> u8 {
+        v.0
     }
 }
 


### PR DESCRIPTION
Currently we have an implementation of `Into` for `u8`, if we implement
`From<u5>` for `u8` we get the `Into` implementation for free.

> One should avoid implementing Into and implement From instead. Implementing From automatically provides one with an implementation of Into thanks to the blanket implementation in the standard library.

ref: https://doc.rust-lang.org/std/convert/trait.Into.html