### PR TITLE
Fix Clippy warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -432,7 +432,7 @@ pub enum Variant {
 }
 
 const BECH32_CONST: u32 = 1;
-const BECH32M_CONST: u32 = 0x2bc830a3;
+const BECH32M_CONST: u32 = 0x2bc8_30a3;
 
 impl Variant {
     // Produce the variant based on the remainder of the polymod operation

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -803,6 +803,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::type_complexity)]
     fn valid_conversion() {
         // Set of [data, from_bits, to_bits, pad, result]
         let tests: Vec<(Vec<u8>, u32, u32, bool, Vec<u8>)> = vec![

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -370,13 +370,13 @@ fn check_hrp(hrp: &str) -> Result<Case, Error> {
     let mut has_upper: bool = false;
     for b in hrp.bytes() {
         // Valid subset of ASCII
-        if b < 33 || b > 126 {
+        if !(33..=126).contains(&b) {
             return Err(Error::InvalidChar(b as char));
         }
 
-        if b >= b'a' && b <= b'z' {
+        if (b'a'..=b'z').contains(&b) {
             has_lower = true;
-        } else if b >= b'A' && b <= b'Z' {
+        } else if (b'A'..=b'Z').contains(&b) {
             has_upper = true;
         };
 
@@ -520,7 +520,7 @@ pub fn decode(s: &str) -> Result<(String, Vec<u5>, Variant), Error> {
             // c should be <128 since it is in the ASCII range, CHARSET_REV.len() == 128
             let num_value = CHARSET_REV[c as usize];
 
-            if num_value > 31 || num_value < 0 {
+            if !(0..=31).contains(&num_value) {
                 return Err(Error::InvalidChar(c));
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -406,7 +406,7 @@ pub fn encode_to_fmt<T: AsRef<[u5]>>(
     data: T,
     variant: Variant,
 ) -> Result<fmt::Result, Error> {
-    let hrp_lower = match check_hrp(&hrp)? {
+    let hrp_lower = match check_hrp(hrp)? {
         Case::Upper => Cow::Owned(hrp.to_lowercase()),
         Case::Lower | Case::None => Cow::Borrowed(hrp),
     };
@@ -485,7 +485,7 @@ pub fn decode(s: &str) -> Result<(String, Vec<u5>, Variant), Error> {
         return Err(Error::InvalidLength);
     }
 
-    let mut case = check_hrp(&raw_hrp)?;
+    let mut case = check_hrp(raw_hrp)?;
     let hrp_lower = match case {
         Case::Upper => raw_hrp.to_lowercase(),
         // already lowercase
@@ -529,7 +529,7 @@ pub fn decode(s: &str) -> Result<(String, Vec<u5>, Variant), Error> {
         .collect::<Result<Vec<u5>, Error>>()?;
 
     // Ensure checksum
-    match verify_checksum(&hrp_lower.as_bytes(), &data) {
+    match verify_checksum(hrp_lower.as_bytes(), &data) {
         Some(variant) => {
             // Remove checksum from data payload
             let dbl: usize = data.len();


### PR DESCRIPTION
These warnings do not show up until the MSRV is increased but none of them _require_ the MSRV update i.e., CI should pass still with Rust `1.29`.

This was done in preparation for [updating the MSRV](https://github.com/rust-bitcoin/rust-bech32/pull/57); raising as a separate PR to minimize the changes required for 'Updating edition 2018'.