### PR TITLE
Improve the manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bech32"
 version = "0.9.1"
-authors = ["Clark Moody"]
+authors = ["Clark Moody", "The rust-bitcoin developers"]
 repository = "https://github.com/rust-bitcoin/rust-bech32"
 description = "Encodes and decodes the Bech32 format"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "bech32"
 version = "0.9.1"
 authors = ["Clark Moody", "The rust-bitcoin developers"]
 repository = "https://github.com/rust-bitcoin/rust-bech32"
+documentation = "https://docs.rs/bech32/"
 description = "Encodes and decodes the Bech32 format"
 readme = "README.md"
 keywords = ["base32", "encoding", "bech32"]


### PR DESCRIPTION
In preparation for attempting to stabilize this crate, do a couple of improvements to the manifest.

- Patch 1: Add "The rust-bitcoin developers" to authors field to the `package` section of the manifest, both for attribution and to accept responsibility for mistakes.
- Patch 2: Add a `documentation` field to the `package` section of the manifest
