### PR TITLE
Revert `encode_to_fmt` API change

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bech32"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Clark Moody"]
 repository = "https://github.com/rust-bitcoin/rust-bech32"
 description = "Encodes and decodes the Bech32 format"


### PR DESCRIPTION
Maintaining the original error type allows for making a minor release since it won't break the API. This lets indirect consumers of the crate through `rust-bitcoin`'s module re-export to use new functions (e.g., `encode_without_checksum`) without a new `rust-bitcoin` release.