### PR TITLE
Fix recent "alloc" feature fail

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,82 +1,79 @@
-on: [pull_request]
+on: [push, pull_request]
 
 name: Continuous Integration
 
 jobs:
-  Test:
-    name: Test Suite
+  Stable:
+    name: Test - stable toolchain
     runs-on: ubuntu-latest
     strategy:
-      matrix:
-        rust:
-          - 1.41.1
-          - stable
-          - nightly
+      fail-fast: false
     steps:
       - name: Checkout Crate
-      - uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Checkout Toolchain
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          override: true
-      - name: Run Test Script
-        env: ${{ matrix.rust }}
+        # https://github.com/dtolnay/rust-toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Running test script
+        env:
+          DO_LINT: true
         run: ./contrib/test.sh
 
-  fmt:
-    name: Rustfmt
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
-      - run: rustup component add rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
-
-  clippy:
-    name: Clippy
+  Beta:
+    name: Test - beta toolchain
     runs-on: ubuntu-latest
     strategy:
-      matrix:
-        rust:
-          - stable
+      fail-fast: false
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          override: true
-      - run: rustup component add clippy
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings
+      - name: Checkout Crate
+        uses: actions/checkout@v3
+      - name: Checkout Toolchain
+        uses: dtolnay/rust-toolchain@beta
+      - name: Running test script
+        run: ./contrib/test.sh
+
+  Nightly:
+    name: Test - nightly toolchain
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout Crate
+        uses: actions/checkout@v3
+      - name: Checkout Toolchain
+        uses: dtolnay/rust-toolchain@nightly
+      - name: Running test script
+        env:
+          DO_FMT: true
+        run: ./contrib/test.sh
+
+  MSRV:
+    name: Test - 1.41.1 toolchain
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout Crate
+        uses: actions/checkout@v3
+      - name: Checkout Toolchain
+        uses: dtolnay/rust-toolchain@1.41.1
+      - name: Running test script
+        run: ./contrib/test.sh
 
   EmbeddedWithAlloc:
     name: no_std with alloc
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+      - name: Checkout Crate
+        uses: actions/checkout@v3
       - name: Set up QEMU
         run: sudo apt update && sudo apt install -y qemu-system-arm gcc-arm-none-eabi
       - name: Checkout Toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@nightly
         with:
-          profile: minimal
-          toolchain: nightly
-          override: true
-          components: rust-src
-          target: thumbv7m-none-eabi
+          targets: thumbv7m-none-eabi
       - name: Run
         env:
           RUSTFLAGS: "-C link-arg=-Tlink.x"
@@ -87,14 +84,11 @@ jobs:
     name: no_std no alloc
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: rustc
-          args: -- -C link-arg=-nostartfiles
+      - name: Checkout Crate
+        uses: actions/checkout@v3
+      - name: Checkout Toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run
+        run: cd embedded/no-allocator && cargo rustc -- -C link-arg=-nostartfiles

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -6,15 +6,39 @@
 
 set -ex
 
+FEATURES="std alloc"
+
+# Some tests require certain toolchain types.
+NIGHTLY=false
+if cargo --version | grep nightly; then
+    NIGHTLY=true
+fi
+
 # Sanity, check tools exist.
 cargo --version
 rustc --version
+
+# Run the linter if told to.
+if [ "$DO_LINT" = true ]
+then
+    cargo clippy --all-features --all-targets -- -D warnings
+fi
+
+# Run formatter if told to.
+if [ "$DO_FMT" = true ]; then
+    if [ "$NIGHTLY" = false ]; then
+        echo "DO_FMT requires a nightly toolchain (consider using RUSTUP_TOOLCHAIN)"
+        exit 1
+    fi
+    rustup component add rustfmt
+    cargo fmt --check
+fi
 
 # Check without features ("strict" is a CI feature only, see above).
 cargo build --no-default-features --features="strict"
 cargo test --no-default-features --features="strict"
 
-# Check "std" feature (implies "alloc").
+# Check "std" feature (implies "alloc", so this is equivalent to --all-features).
 cargo build --no-default-features --features="strict std"
 cargo test --no-default-features --features="strict std"
 

--- a/embedded/with-allocator/Cargo.toml
+++ b/embedded/with-allocator/Cargo.toml
@@ -11,7 +11,7 @@ cortex-m-rt = "0.6.10"
 cortex-m-semihosting = "0.3.3"
 panic-halt = "0.2.0"
 alloc-cortex-m = "0.4.1"
-bech32 = { path="../../", default-features = false }
+bech32 = { path="../../", default-features = false, features = ["alloc"] }
 
 [[bin]]
 name = "with-allocator"


### PR DESCRIPTION
Recently in #71 I introduced a bucket  load of bugs, in CI and in the `with-allocator` crate (which was not being run correctly in CI).

- Patch 1 enables the "alloc" feature in the `with-allocator` crate.
- Patch 2 totally overhauls the github actions
