### PR TITLE
Add benchmarks

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,6 +48,7 @@ jobs:
         env:
           DO_DOCSRS: true
           DO_FMT: true
+          DO_BENCH: true
         run: ./contrib/test.sh
 
   MSRV:

--- a/README.md
+++ b/README.md
@@ -27,3 +27,9 @@ git config --local core.hooksPath githooks/
 ```
 
 Alternatively add symlinks in your `.git/hooks` directory to any of the githooks we provide.
+
+
+## Benchmarks
+
+We use a custom Rust compiler configuration conditional to guard the benchmark code. To run the
+benchmarks use: `RUSTFLAGS='--cfg=bench' cargo +nightly bench`.

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -71,4 +71,16 @@ if [ "${DO_DOCS-false}" = true ]; then
     RUSTDOCFLAGS="-D warnings" cargo +stable doc --all-features
 fi
 
+# Bench if told to.
+if [ "${DO_BENCH-false}" = true ]
+then
+    # Technically we could use beta too but we only run this in CI using nightly.
+    if [ "$NIGHTLY" = false ]; then
+        echo "DO_BENCH requires a nightly toolchain (consider using RUSTUP_TOOLCHAIN)"
+        exit 1
+    fi
+
+    RUSTFLAGS='--cfg=bench' cargo bench
+fi
+
 exit 0


### PR DESCRIPTION
Add benchmarks for parsing and encoding bitcoin addresses. Also add two unit tests that parse the same address string used in the benchmarks.
    
Specifically benchmark:
    
- decoding an address
- encoding an address with allocation
- encoding an address without allocation
    
Do so for both Bitcoin bech32 addresses and Bitcoin bech32m addresses.


Patch 1 is preparatory clean up to the readme.