### PR TITLE
use new `Fe32` type in place of `gf32`

### DIFF
--- a/src/primitives/gf32.rs
+++ b/src/primitives/gf32.rs
@@ -307,7 +307,7 @@ impl ops::DivAssign for Fe32 {
 }
 
 /// A galois field related error.
-#[derive(Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[non_exhaustive]
 pub enum Error {
     /// Tried to interpret an integer as a GF32 element but it could not be converted to an u8.


### PR DESCRIPTION
This requires dropping `Ord` impls from the error types, but IMHO these didn't really make sense anyway.

This also keeps the `u5` name. We will rename this in a later PR which replaces the *Base32 traits with iterator adaptors, since at that point there will be a much smaller API surface to change.

Followup to #98.