### PR TITLE
Add `Hrp` type

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        fuzz_target: [decode_rnd, encode_decode]
+        fuzz_target: [decode_rnd, encode_decode, parse_hrp]
     steps:
       - name: Install test dependencies
         run: sudo apt-get update -y && sudo apt-get install -y binutils-dev libunwind8-dev libcurl4-openssl-dev libelf-dev libdw-dev cmake gcc libiberty-dev

--- a/embedded/no-allocator/src/main.rs
+++ b/embedded/no-allocator/src/main.rs
@@ -10,7 +10,7 @@
 use panic_halt as _;
 
 use arrayvec::{ArrayString, ArrayVec};
-use bech32::{self, u5, ComboError, FromBase32, ToBase32, Variant};
+use bech32::{self, u5, ComboError, FromBase32, ToBase32, Variant, Hrp};
 use cortex_m_rt::entry;
 use cortex_m_semihosting::{debug, hprintln};
 
@@ -24,7 +24,9 @@ fn main() -> ! {
 
     [0x00u8, 0x01, 0x02].write_base32(&mut base32).unwrap();
 
-    bech32::encode_to_fmt_anycase(&mut encoded, "bech32", &base32, Variant::Bech32)
+    let hrp = Hrp::parse("bech32").unwrap();
+
+    bech32::encode_to_fmt_anycase(&mut encoded, hrp, &base32, Variant::Bech32)
         .unwrap()
         .unwrap();
     test(&*encoded == "bech321qqqsyrhqy2a");
@@ -35,9 +37,9 @@ fn main() -> ! {
 
     let mut scratch = ArrayVec::<u5, 30>::new();
 
-    let (hrp, data, variant) =
+    let (got_hrp, data, variant) =
         bech32::decode_lowercase::<ComboError, _, _>(&encoded, &mut decoded, &mut scratch).unwrap();
-    test(hrp == "bech32");
+    test(got_hrp == hrp);
     let res = ArrayVec::<u8, 30>::from_base32(&data).unwrap();
     test(&res == [0x00, 0x01, 0x02].as_ref());
     test(variant == Variant::Bech32);

--- a/embedded/with-allocator/src/main.rs
+++ b/embedded/with-allocator/src/main.rs
@@ -11,7 +11,7 @@ use self::alloc::vec::Vec;
 use core::alloc::Layout;
 
 use alloc_cortex_m::CortexMHeap;
-use bech32::{self, FromBase32, ToBase32, Variant};
+use bech32::{self, FromBase32, ToBase32, Variant, Hrp};
 use cortex_m::asm;
 use cortex_m_rt::entry;
 use cortex_m_semihosting::{debug, hprintln};
@@ -26,8 +26,9 @@ fn main() -> ! {
     // Initialize the allocator BEFORE you use it
     unsafe { ALLOCATOR.init(cortex_m_rt::heap_start() as usize, HEAP_SIZE) }
 
+    let hrp = Hrp::parse("bech32").unwrap();
     let encoded = bech32::encode(
-        "bech32",
+        hrp,
         vec![0x00, 0x01, 0x02].to_base32(),
         Variant::Bech32,
     )
@@ -36,8 +37,8 @@ fn main() -> ! {
 
     hprintln!("{}", encoded).unwrap();
 
-    let (hrp, data, variant) = bech32::decode(&encoded).unwrap();
-    test(hrp == "bech32");
+    let (got_hrp, data, variant) = bech32::decode(&encoded).unwrap();
+    test(got_hrp == hrp);
     test(Vec::<u8>::from_base32(&data).unwrap() == vec![0x00, 0x01, 0x02]);
     test(variant == Variant::Bech32);
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -28,3 +28,7 @@ path = "fuzz_targets/decode_rnd.rs"
 [[bin]]
 name = "encode_decode"
 path = "fuzz_targets/encode_decode.rs"
+
+[[bin]]
+name = "parse_hrp"
+path = "fuzz_targets/parse_hrp.rs"

--- a/fuzz/fuzz_targets/parse_hrp.rs
+++ b/fuzz/fuzz_targets/parse_hrp.rs
@@ -1,14 +1,13 @@
 extern crate bech32;
 
-fn do_test(data: &[u8]) {
-    let data_str = String::from_utf8_lossy(data);
-    let decoded = bech32::decode(&data_str);
-    let b32 = match decoded {
-        Ok(b32) => b32,
-        Err(_) => return,
-    };
+use bech32::Hrp;
 
-    assert_eq!(bech32::encode(b32.0, b32.1, b32.2).unwrap(), data_str);
+fn do_test(data: &[u8]) {
+    let s = String::from_utf8_lossy(data);
+
+    // Make sure parsing garbage doesn't make us crash (from_utf8_lossy should
+    // contain some garbage, perhaps even invalid chars).
+    let _ = Hrp::parse(&s);
 }
 
 #[cfg(feature = "afl")]
@@ -36,7 +35,7 @@ fn main() {
 mod tests {
     fn extend_vec_from_hex(hex: &str, out: &mut Vec<u8>) {
         let mut b = 0;
-        for (idx, c) in hex.as_bytes().iter().enumerate() {
+        for (idx, c) in hex.as_bytes().iter().filter(|&&c| c != b'\n').enumerate() {
             b <<= 4;
             match *c {
                 b'A'...b'F' => b |= c - b'A' + 10,
@@ -54,7 +53,7 @@ mod tests {
     #[test]
     fn duplicate_crash() {
         let mut a = Vec::new();
-        extend_vec_from_hex("00000000", &mut a);
+        extend_vec_from_hex("ff6c2d", &mut a);
         super::do_test(&a);
     }
 }

--- a/src/primitives/hrp.rs
+++ b/src/primitives/hrp.rs
@@ -1,0 +1,467 @@
+// SPDX-License-Identifier: MIT
+
+//! Provides an `Hrp` type that represents the human-readable part of a bech32 encoded string.
+//!
+//! > The human-readable part, which is intended to convey the type of data, or anything else that
+//! > is relevant to the reader. This part MUST contain 1 to 83 US-ASCII characters, with each
+//! > character having a value in the range [33-126]. HRP validity may be further restricted by
+//! > specific applications.
+//!
+//! ref: [BIP-173](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#user-content-Bech32)
+
+#[cfg(feature = "alloc")]
+use alloc::string::String;
+use core::cmp::Ordering;
+use core::fmt::{self, Write};
+use core::iter::FusedIterator;
+use core::slice;
+
+use crate::Case;
+
+/// Maximum length of the human-readable part, as defined by BIP-173.
+const MAX_HRP_LEN: usize = 83;
+
+/// The human-readable part (human readable prefix before the '1' separator).
+#[derive(Clone, Copy, Debug)]
+pub struct Hrp {
+    /// ASCII byte values, guaranteed not to be mixed-case.
+    buf: [u8; MAX_HRP_LEN],
+    /// Number of characters currently stored in this HRP.
+    size: usize,
+}
+
+impl Hrp {
+    /// Parses the human-readable part checking it is valid as defined by [BIP-173].
+    ///
+    /// This does _not_ check that the `hrp` is an in-use HRP within Bitcoin (eg, "bc"), rather it
+    /// checks that the HRP string is valid as per the specification in [BIP-173]:
+    ///
+    /// > The human-readable part, which is intended to convey the type of data, or anything else that
+    /// > is relevant to the reader. This part MUST contain 1 to 83 US-ASCII characters, with each
+    /// > character having a value in the range [33-126]. HRP validity may be further restricted by
+    /// > specific applications.
+    ///
+    /// [BIP-173]: <https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki>
+    pub fn parse(hrp: &str) -> Result<Self, Error> { Ok(Self::parse_and_case(hrp)?.0) }
+
+    /// Parses the human-readable part (see [`Hrp::parse`] for full docs).
+    ///
+    /// # Panics
+    ///
+    /// If the string is invalid as defined by BIP-173.
+    pub const fn parse_unchecked(hrp: &str) -> Self {
+        let mut new = Hrp { buf: [0_u8; MAX_HRP_LEN], size: 0 };
+        let hrp_bytes = hrp.as_bytes();
+
+        let mut i = 0;
+        // Funky code so we can be const.
+        while i < hrp.len() {
+            let b = hrp_bytes[i];
+            // Valid subset of ASCII
+            if b < 33 || b > 126 {
+                panic!("invalid hrp");
+            }
+
+            new.buf[i] = hrp_bytes[i];
+            new.size += 1;
+            i += 1;
+        }
+        new
+    }
+
+    /// Returns the case as well as the parsed `Hrp`.
+    pub(crate) fn parse_and_case(hrp: &str) -> Result<(Self, Case), Error> {
+        use Error::*;
+
+        let mut new = Hrp { buf: [0_u8; MAX_HRP_LEN], size: 0 };
+
+        if hrp.is_empty() {
+            return Err(Empty);
+        }
+        if hrp.len() > MAX_HRP_LEN {
+            return Err(TooLong(hrp.len()));
+        }
+
+        let mut has_lower: bool = false;
+        let mut has_upper: bool = false;
+        for (i, c) in hrp.chars().enumerate() {
+            if !c.is_ascii() {
+                return Err(NonAsciiChar(c));
+            }
+            let b = c as u8; // cast OK as we just checked that c is an ASCII value
+
+            // Valid subset of ASCII
+            if !(33..=126).contains(&b) {
+                return Err(InvalidAsciiByte(b));
+            }
+
+            if b.is_ascii_lowercase() {
+                has_lower = true;
+            } else if b.is_ascii_uppercase() {
+                has_upper = true;
+            };
+
+            new.buf[i] = b;
+            new.size += 1;
+        }
+
+        let case = match (has_lower, has_upper) {
+            (true, false) => Case::Lower,
+            (false, true) => Case::Upper,
+            (false, false) => Case::None,
+            (true, true) => return Err(MixedCase),
+        };
+
+        Ok((new, case))
+    }
+
+    /// Lowercase the inner ASCII bytes of this HRP.
+    // This is a hack to support `encode_to_fmt`, we should remove this function.
+    pub(crate) fn lowercase(&mut self) {
+        for b in self.buf.iter_mut() {
+            if is_ascii_uppercase(*b) {
+                *b |= 32;
+            }
+        }
+    }
+
+    /// Returns this human-readable part as a lowercase string.
+    #[cfg(feature = "alloc")]
+    pub fn to_lowercase(&self) -> String { self.lowercase_char_iter().collect() }
+
+    /// Creates a byte iterator over the ASCII byte values (ASCII characters) of this HRP.
+    ///
+    /// If an uppercase HRP was parsed during object construction then this iterator will yield
+    /// uppercase ASCII `char`s. For lowercase bytes see [`Self::lowercase_byte_iter`]
+    pub fn byte_iter(&self) -> ByteIter { ByteIter { iter: self.buf[..self.size].iter() } }
+
+    /// Creates a character iterator over the ASCII characters of this HRP.
+    ///
+    /// If an uppercase HRP was parsed during object construction then this iterator will yield
+    /// uppercase ASCII `char`s. For lowercase bytes see [`Self::lowercase_char_iter`].
+    pub fn char_iter(&self) -> CharIter { CharIter { iter: self.byte_iter() } }
+
+    /// Creates a lowercase iterator over the byte values (ASCII characters) of this HRP.
+    pub fn lowercase_byte_iter(&self) -> LowercaseByteIter {
+        LowercaseByteIter { iter: self.byte_iter() }
+    }
+
+    /// Creates a lowercase character iterator over the ASCII characters of this HRP.
+    pub fn lowercase_char_iter(&self) -> LowercaseCharIter {
+        LowercaseCharIter { iter: self.lowercase_byte_iter() }
+    }
+
+    /// Returns the length (number of characters) of the human-readable part.
+    ///
+    /// Guaranteed to be between 1 and 83 inclusive.
+    pub fn len(&self) -> usize { self.size }
+
+    /// Always false, the human-readable part is guaranteed to be between 1-83 characters.
+    pub fn is_empty(&self) -> bool { false }
+}
+
+/// Displays the human-readable part.
+///
+/// If an uppercase HRP was parsed during object construction then the returned string will be
+/// in uppercase also. For a lowercase string see [`Self::to_lowercase`].
+impl fmt::Display for Hrp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for c in self.char_iter() {
+            f.write_char(c)?;
+        }
+        Ok(())
+    }
+}
+
+/// Case insensitive comparison.
+impl Ord for Hrp {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.lowercase_byte_iter().cmp(other.lowercase_byte_iter())
+    }
+}
+
+/// Case insensitive comparison.
+impl PartialOrd for Hrp {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> { Some(self.cmp(other)) }
+}
+
+/// Case insensitive comparison.
+impl PartialEq for Hrp {
+    fn eq(&self, other: &Self) -> bool {
+        self.lowercase_byte_iter().eq(other.lowercase_byte_iter())
+    }
+}
+
+impl Eq for Hrp {}
+
+impl core::hash::Hash for Hrp {
+    fn hash<H: core::hash::Hasher>(&self, h: &mut H) { self.buf.hash(h) }
+}
+
+/// Iterator over bytes (ASCII values) of the human-readable part.
+///
+/// ASCII byte values as they were initially parsed (i.e., in the original case).
+pub struct ByteIter<'b> {
+    iter: slice::Iter<'b, u8>,
+}
+
+impl<'b> Iterator for ByteIter<'b> {
+    type Item = u8;
+    fn next(&mut self) -> Option<u8> { self.iter.next().copied() }
+
+    fn size_hint(&self) -> (usize, Option<usize>) { (self.len(), Some(self.len())) }
+}
+
+impl<'b> ExactSizeIterator for ByteIter<'b> {
+    fn len(&self) -> usize { self.iter.len() }
+}
+
+impl<'b> DoubleEndedIterator for ByteIter<'b> {
+    fn next_back(&mut self) -> Option<Self::Item> { self.iter.next_back().copied() }
+}
+
+impl<'b> FusedIterator for ByteIter<'b> {}
+
+/// Iterator over ASCII characters of the human-readable part.
+///
+/// ASCII `char`s as they were initially parsed (i.e., in the original case).
+pub struct CharIter<'b> {
+    iter: ByteIter<'b>,
+}
+
+impl<'b> Iterator for CharIter<'b> {
+    type Item = char;
+    fn next(&mut self) -> Option<char> { self.iter.next().map(Into::into) }
+
+    fn size_hint(&self) -> (usize, Option<usize>) { (self.len(), Some(self.len())) }
+}
+
+impl<'b> ExactSizeIterator for CharIter<'b> {
+    fn len(&self) -> usize { self.iter.len() }
+}
+
+impl<'b> DoubleEndedIterator for CharIter<'b> {
+    fn next_back(&mut self) -> Option<Self::Item> { self.iter.next_back().map(Into::into) }
+}
+
+impl<'b> FusedIterator for CharIter<'b> {}
+
+/// Iterator over lowercase bytes (ASCII characters) of the human-readable part.
+pub struct LowercaseByteIter<'b> {
+    iter: ByteIter<'b>,
+}
+
+impl<'b> Iterator for LowercaseByteIter<'b> {
+    type Item = u8;
+    fn next(&mut self) -> Option<u8> {
+        self.iter.next().map(|b| if is_ascii_uppercase(b) { b | 32 } else { b })
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) { (self.len(), Some(self.len())) }
+}
+
+impl<'b> ExactSizeIterator for LowercaseByteIter<'b> {
+    fn len(&self) -> usize { self.iter.len() }
+}
+
+impl<'b> DoubleEndedIterator for LowercaseByteIter<'b> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.iter.next_back().map(|b| if is_ascii_uppercase(b) { b | 32 } else { b })
+    }
+}
+
+impl<'b> FusedIterator for LowercaseByteIter<'b> {}
+
+/// Iterator over lowercase ASCII characters of the human-readable part.
+pub struct LowercaseCharIter<'b> {
+    iter: LowercaseByteIter<'b>,
+}
+
+impl<'b> Iterator for LowercaseCharIter<'b> {
+    type Item = char;
+    fn next(&mut self) -> Option<char> { self.iter.next().map(Into::into) }
+
+    fn size_hint(&self) -> (usize, Option<usize>) { (self.len(), Some(self.len())) }
+}
+
+impl<'b> ExactSizeIterator for LowercaseCharIter<'b> {
+    fn len(&self) -> usize { self.iter.len() }
+}
+
+impl<'b> DoubleEndedIterator for LowercaseCharIter<'b> {
+    fn next_back(&mut self) -> Option<Self::Item> { self.iter.next_back().map(Into::into) }
+}
+
+impl<'b> FusedIterator for LowercaseCharIter<'b> {}
+
+fn is_ascii_uppercase(b: u8) -> bool { (65..=90).contains(&b) }
+
+/// Errors encountered while checking the human-readable part as defined by [BIP-173].
+/// [BIP-173]: <https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#user-content-Bech32>
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Error {
+    /// The human-readable part is too long.
+    TooLong(usize),
+    /// The human-readable part is empty.
+    Empty,
+    /// Found a non-ASCII character.
+    NonAsciiChar(char),
+    /// Byte value not within acceptable US-ASCII range.
+    InvalidAsciiByte(u8),
+    /// The human-readable part cannot mix upper and lower case.
+    MixedCase,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use Error::*;
+
+        match *self {
+            TooLong(len) => write!(f, "hrp is too long, found {} characters, must be <= 126", len),
+            Empty => write!(f, "hrp is empty, must have at least 1 character"),
+            NonAsciiChar(c) => write!(f, "found non-ASCII character: {}", c),
+            InvalidAsciiByte(b) => write!(f, "byte value is not valid US-ASCII: \'{:x}\'", b),
+            MixedCase => write!(f, "hrp cannot mix upper and lower case"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use Error::*;
+
+        match *self {
+            TooLong(_) | Empty | NonAsciiChar(_) | InvalidAsciiByte(_) | MixedCase => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    macro_rules! check_parse_ok {
+        ($($test_name:ident, $hrp:literal);* $(;)?) => {
+            $(
+                #[test]
+                fn $test_name() {
+                    assert!(Hrp::parse($hrp).is_ok());
+                }
+            )*
+        }
+    }
+    check_parse_ok! {
+        parse_ok_0, "a";
+        parse_ok_1, "A";
+        parse_ok_2, "abcdefg";
+        parse_ok_3, "ABCDEFG";
+        parse_ok_4, "abc123def";
+        parse_ok_5, "ABC123DEF";
+        parse_ok_6, "!\"#$%&'()*+,-./";
+        parse_ok_7, "1234567890";
+    }
+
+    macro_rules! check_parse_err {
+        ($($test_name:ident, $hrp:literal);* $(;)?) => {
+            $(
+                #[test]
+                fn $test_name() {
+                    assert!(Hrp::parse($hrp).is_err());
+                }
+            )*
+        }
+    }
+    check_parse_err! {
+        parse_err_0, "has-capitals-aAbB";
+        parse_err_1, "has-value-out-of-range-∈∈∈∈∈∈∈∈";
+        parse_err_2, "toolongtoolongtoolongtoolongtoolongtoolongtoolongtoolongtoolongtoolongtoolongtoolongtoolongtoolong";
+        parse_err_3, "has spaces in it";
+    }
+
+    macro_rules! check_case {
+        ($($test_name:ident, $hrp:literal, $expected:ident);* $(;)?) => {
+            $(
+                #[test]
+                fn $test_name() {
+                    use crate::Case::*;
+                    let (_, case) = Hrp::parse_and_case($hrp).expect("failed to parse hrp");
+                    assert_eq!(case, $expected);
+                }
+            )*
+        }
+    }
+    check_case! {
+        case_0, "a", Lower;
+        case_1, "A", Upper;
+        case_2, "ab", Lower;
+        case_3, "AB", Upper;
+        case_4, "ab2", Lower;
+        case_5, "AB2", Upper;
+        case_6, "3ab2", Lower;
+        case_7, "3AB2", Upper;
+        case_8, "2", None;
+        case_9, "23456", None;
+    }
+
+    macro_rules! check_iter {
+        ($($test_name:ident, $hrp:literal, $len:literal);* $(;)?) => {
+            $(
+                #[test]
+                fn $test_name() {
+                    let hrp = Hrp::parse($hrp).expect(&format!("failed to parse hrp {}", $hrp));
+
+                    // Test ByteIter forwards.
+                    for (got, want) in hrp.byte_iter().zip($hrp.bytes()) {
+                        assert_eq!(got, want);
+                    }
+
+                    // Test ByteIter backwards.
+                    for (got, want) in hrp.byte_iter().rev().zip($hrp.bytes().rev()) {
+                        assert_eq!(got, want);
+                    }
+
+                    // Test exact sized works.
+                    let mut iter = hrp.byte_iter();
+                    for i in 0..$len {
+                        assert_eq!(iter.len(), $len - i);
+                        let _ = iter.next();
+                    }
+                    assert!(iter.next().is_none());
+
+                    // Test CharIter forwards.
+                    let iter = hrp.char_iter();
+                    assert_eq!($hrp.to_string(), iter.collect::<String>());
+
+                    for (got, want) in hrp.char_iter().zip($hrp.chars()) {
+                        assert_eq!(got, want);
+                    }
+
+                    // Test CharIter backwards.
+                    for (got, want) in hrp.char_iter().rev().zip($hrp.chars().rev()) {
+                        assert_eq!(got, want);
+                    }
+
+                    // Test LowercaseCharIter forwards (implicitly tests LowercaseByteIter)
+                    for (got, want) in hrp.lowercase_char_iter().zip($hrp.chars().map(|c| c.to_ascii_lowercase())) {
+                        assert_eq!(got, want);
+                    }
+
+                    // Test LowercaseCharIter backwards (implicitly tests LowercaseByteIter)
+                    for (got, want) in hrp.lowercase_char_iter().rev().zip($hrp.chars().rev().map(|c| c.to_ascii_lowercase())) {
+                        assert_eq!(got, want);
+                    }
+                }
+            )*
+        }
+    }
+    check_iter! {
+        char_0, "abc", 3;
+        char_1, "ABC", 3;
+        char_2, "abc123", 6;
+        char_3, "ABC123", 6;
+        char_4, "abc123def", 9;
+        char_5, "ABC123DEF", 9;
+    }
+}

--- a/src/primitives/mod.rs
+++ b/src/primitives/mod.rs
@@ -6,5 +6,7 @@
 //! ## Overview
 //!
 //! - `gf32`: GF32 elements, i.e. "bech32 characters".
+//! - `hrp`: human-readable part.
 
 pub mod gf32;
+pub mod hrp;


### PR DESCRIPTION
Instead of accepting `&str` for hrp strings we can add a type `Hrp` and abstract the checking of the string. This is the "parse don't validate" methodology suggested by clarkmoody [here](https://github.com/rust-bitcoin/rust-bech32/pull/100#issuecomment-1512435732).

This is an invasive breaking change.
