### PR TITLE
Add iter and checksum modules

### DIFF
--- a/src/primitives/checksum.rs
+++ b/src/primitives/checksum.rs
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: MIT
+
+//! Degree-2 [BCH] code checksum.
+//!
+//! [BCH]: <https://en.wikipedia.org/wiki/BCH_code>
+
+use core::{mem, ops};
+
+use crate::primitives::gf32::Fe32;
+use crate::primitives::hrp::Hrp;
+
+/// Trait defining a particular checksum.
+///
+/// For users, this can be treated as a marker trait; none of the associated data
+/// are end-user relevant.
+pub trait Checksum {
+    /// An unsigned integer type capable of holding a packed version of the generator
+    /// polynomial (without its leading 1) and target residue (which will have the
+    /// same width).
+    ///
+    /// Generally, this is the number of characters in the checksum times 5. So e.g.
+    /// for bech32, which has a 6-character checksum, we need 30 bits, so we can use
+    /// u32 here.
+    ///
+    /// The smallest type possible should be used, for efficiency reasons, but the
+    /// only operations we do on these types are bitwise xor and shifts, so it should
+    /// be pretty efficient no matter what.
+    type MidstateRepr: PackedFe32;
+
+    /// The number of characters in the checksum.
+    ///
+    /// Alternately, the degree of the generator polynomial. This is **not** the same
+    /// as the "length of the code", which is the maximum number of characters that
+    /// the checksum can usefully cover.
+    const CHECKSUM_LENGTH: usize;
+
+    /// The coefficients of the generator polynomial, except the leading monic term,
+    /// in "big-endian" (highest-degree coefficients get leftmost bits) order, along
+    /// with the 4 shifts of the generator.
+    ///
+    /// The shifts are literally the generator polynomial left-shifted (i.e. multiplied
+    /// by the appropriate power of 2) in the field. That is, the 5 entries in this
+    /// array are the generator times { P, Z, Y, G, S } in that order.
+    ///
+    /// These cannot be usefully pre-computed because of Rust's limited constfn support
+    /// as of 1.67, so they must be specified manually for each checksum. To check the
+    /// values for consistency, run `Self::sanity_check()`.
+    const GENERATOR_SH: [Self::MidstateRepr; 5];
+
+    /// The residue, modulo the generator polynomial, that a valid codeword will have.
+    const TARGET_RESIDUE: Self::MidstateRepr;
+
+    /// Sanity checks that the various constants of the trait are set in a way that they
+    /// are consistent with each other.
+    ///
+    /// This function never needs to be called by users, but anyone defining a checksum
+    /// should add a unit test to their codebase which calls this.
+    fn sanity_check() {
+        // Check that the declared midstate type can actually hold the whole checksum.
+        assert!(Self::CHECKSUM_LENGTH <= Self::MidstateRepr::WIDTH);
+
+        // Check that the provided generator polynomials are, indeed, the same polynomial just shifted.
+        for i in 1..5 {
+            for j in 0..Self::MidstateRepr::WIDTH {
+                let last = Self::GENERATOR_SH[i - 1].unpack(j);
+                let curr = Self::GENERATOR_SH[i].unpack(j);
+                // GF32 is defined by extending GF2 with a root of x^5 + x^3 + 1 = 0
+                // which when written as bit coefficients is 41 = 0. Hence xoring
+                // (adding, in GF32) by 41 is the way to reduce x^5.
+                assert_eq!(
+                    curr,
+                    (last << 1) ^ if last & 0x10 == 0x10 { 41 } else { 0 },
+                    "Element {} of generator << 2^{} was incorrectly computed. (Should have been {} << 1)",
+                    j, i, last,
+                );
+            }
+        }
+    }
+}
+
+/// A checksum engine, which can be used to compute or verify a checksum.
+///
+/// Use this to verify a checksum, feed it the data to be checksummed using
+/// the `Self::input_*` methods.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct Engine<Ck: Checksum> {
+    residue: Ck::MidstateRepr,
+}
+
+impl<Ck: Checksum> Default for Engine<Ck> {
+    fn default() -> Self { Self::new() }
+}
+
+impl<Ck: Checksum> Engine<Ck> {
+    /// Constructs a new checksum engine with no data input.
+    pub fn new() -> Self { Engine { residue: Ck::MidstateRepr::ONE } }
+
+    /// Feeds `hrp` into the checksum engine.
+    pub fn input_hrp(&mut self, hrp: &Hrp) {
+        for b in hrp.lowercase_byte_iter() {
+            self.input_fe(Fe32(b >> 5));
+        }
+        self.input_fe(Fe32::Q);
+        for b in hrp.lowercase_byte_iter() {
+            self.input_fe(Fe32(b & 0x1f));
+        }
+    }
+
+    /// Adds a single gf32 element to the checksum engine.
+    ///
+    /// This is where the actual checksum computation magic happens.
+    pub fn input_fe(&mut self, e: Fe32) {
+        let xn = self.residue.mul_by_x_then_add(Ck::CHECKSUM_LENGTH, e.into());
+        for i in 0..5 {
+            if xn & (1 << i) != 0 {
+                self.residue = self.residue ^ Ck::GENERATOR_SH[i];
+            }
+        }
+    }
+
+    /// Inputs the target residue of the checksum.
+    ///
+    /// Checksums are generated by appending the target residue to the input
+    /// string, then computing the actual residue, and then replacing the
+    /// target with the actual. This method lets us compute the actual residue
+    /// without doing any string concatenations.
+    pub fn input_target_residue(&mut self) {
+        for i in 0..Ck::CHECKSUM_LENGTH {
+            self.input_fe(Fe32(Ck::TARGET_RESIDUE.unpack(Ck::CHECKSUM_LENGTH - i - 1)));
+        }
+    }
+
+    /// Returns for the current checksum residue.
+    pub fn residue(&self) -> &Ck::MidstateRepr { &self.residue }
+}
+
+/// Trait describing an integer type which can be used as a "packed" sequence of Fe32s.
+///
+/// This is implemented for u32, u64 and u128, as a way to treat these primitive types as
+/// packed coefficients of polynomials over GF32 (up to some maximal degree, of course).
+///
+/// This is useful because then multiplication by x reduces to simply left-shifting by 5,
+/// and addition of entire polynomials can be done by xor.
+pub trait PackedFe32: Copy + PartialEq + Eq + ops::BitXor<Self, Output = Self> {
+    /// The one constant, for which stdlib provides no existing trait.
+    const ONE: Self;
+
+    /// The number of fe32s that can fit into the type; computed as floor(bitwidth / 5).
+    const WIDTH: usize = mem::size_of::<Self>() * 8 / 5;
+
+    /// Extracts the coefficient of the x^n from the packed polynomial.
+    fn unpack(&self, n: usize) -> u8;
+
+    /// Multiply the polynomial by x, drop its highest coefficient (and return it), and
+    /// add a new field element to the now-0 constant coefficient.
+    ///
+    /// Takes the degree of the polynomial as an input; for checksum applications
+    /// this shoud basically always be `Checksum::CHECKSUM_WIDTH`.
+    fn mul_by_x_then_add(&mut self, degree: usize, add: u8) -> u8;
+}
+
+/// A placeholder type used as part of the [`crate::primitives::NoChecksum`] "checksum".
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct PackedNull;
+
+impl ops::BitXor<PackedNull> for PackedNull {
+    type Output = PackedNull;
+    fn bitxor(self, _: PackedNull) -> PackedNull { PackedNull }
+}
+
+impl PackedFe32 for PackedNull {
+    const ONE: Self = PackedNull;
+    fn unpack(&self, _: usize) -> u8 { 0 }
+    fn mul_by_x_then_add(&mut self, _: usize, _: u8) -> u8 { 0 }
+}
+
+macro_rules! impl_packed_fe32 {
+    ($ty:ident) => {
+        impl PackedFe32 for $ty {
+            const ONE: Self = 1;
+
+            fn unpack(&self, n: usize) -> u8 {
+                debug_assert!(n < Self::WIDTH);
+                (*self >> (n * 5)) as u8 & 0x1f
+            }
+
+            fn mul_by_x_then_add(&mut self, degree: usize, add: u8) -> u8 {
+                debug_assert!(degree > 0);
+                debug_assert!(degree <= Self::WIDTH);
+                debug_assert!(add < 32);
+                let ret = self.unpack(degree - 1);
+                *self &= !(0x1f << ((degree - 1) * 5));
+                *self <<= 5;
+                *self |= Self::from(add);
+                ret
+            }
+        }
+    };
+}
+impl_packed_fe32!(u32);
+impl_packed_fe32!(u64);
+impl_packed_fe32!(u128);

--- a/src/primitives/iter.rs
+++ b/src/primitives/iter.rs
@@ -1,0 +1,543 @@
+// SPDX-License-Identifier: MIT
+
+//! Iterator Adaptors
+//!
+//! This module provides iterator adaptors that can be used to verify and generate checksums, HRP
+//! strings, etc., in a variety of ways, without any allocations.
+//!
+//! In general, directly using these adaptors is not very ergonomic, and users are recommended to
+//! instead use the higher-level functions at the root of this crate.
+//!
+//! # Examples
+//!
+//! ```rust
+//! use bech32::primitives::iter::{ByteIterExt, Fe32IterExt};
+//! use bech32::primitives::gf32::Fe32;
+//! use bech32::primitives::hrp::Hrp;
+//! use bech32::primitives::Bech32;
+//!
+//! let witness_prog = [
+//!     0x75, 0x1e, 0x76, 0xe8, 0x19, 0x91, 0x96, 0xd4,
+//!     0x54, 0x94, 0x1c, 0x45, 0xd1, 0xb3, 0xa3, 0x23,
+//!     0xf1, 0x43, 0x3b, 0xd6,
+//! ];
+//! let hrp = Hrp::parse_unchecked("bc");
+//! let iterator = witness_prog
+//!     .iter()
+//!     .copied() // Iterate over bytes.
+//!     .bytes_to_fes() // Convert bytes to field elements in-line.
+//!     .with_witness_version(Fe32::Q) // Witness version 0.
+//!     .checksum::<Bech32>() // Convert to a [`ChecksumIter`] (append a bech32 checksum).
+//!     .with_checksummed_hrp(&hrp) // Feed HRP into the checksum.
+//!     .hrp_char(&hrp); // Turn the fe stream into a char stream with HRP.
+//! let hrpstring: String = iterator.collect();
+//! assert_eq!(hrpstring.to_uppercase(), "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4");
+//! ```
+
+use core::iter::FusedIterator;
+
+use crate::primitives::checksum::{self, Checksum, PackedFe32};
+use crate::primitives::gf32::Fe32;
+use crate::primitives::hrp::{self, Hrp};
+
+/// Extension trait for byte iterators which provides an adaptor to GF32 elements
+pub trait ByteIterExt: Sized + ExactSizeIterator + FusedIterator + Iterator<Item = u8> {
+    /// Obtain the GF32 iterator
+    fn bytes_to_fes(mut self) -> ByteToFeIter<Self> {
+        ByteToFeIter { last_byte: self.next(), bit_offset: 0, iter: self }
+    }
+}
+impl<I> ByteIterExt for I where I: ExactSizeIterator + FusedIterator + Iterator<Item = u8> {}
+
+/// Iterator adaptor that converts bytes to GF32 elements. If the total number
+/// of bits is not a multiple of 5, it right-pads with 0 bits.
+#[derive(Clone, PartialEq, Eq)]
+pub struct ByteToFeIter<I: ExactSizeIterator + FusedIterator + Iterator<Item = u8>> {
+    last_byte: Option<u8>,
+    bit_offset: usize,
+    iter: I,
+}
+
+impl<I> Iterator for ByteToFeIter<I>
+where
+    I: ExactSizeIterator + FusedIterator + Iterator<Item = u8>,
+{
+    type Item = Fe32;
+    fn next(&mut self) -> Option<Fe32> {
+        use core::cmp::Ordering::*;
+
+        let bit_offset = {
+            let ret = self.bit_offset;
+            self.bit_offset = (self.bit_offset + 5) % 8;
+            ret
+        };
+
+        if let Some(last) = self.last_byte {
+            match bit_offset.cmp(&3) {
+                Less => Some(Fe32((last >> (3 - bit_offset)) & 0x1f)),
+                Equal => {
+                    self.last_byte = self.iter.next();
+                    Some(Fe32(last & 0x1f))
+                }
+                Greater => {
+                    self.last_byte = self.iter.next();
+                    let next = self.last_byte.unwrap_or(0);
+                    Some(Fe32(((last << (bit_offset - 3)) | (next >> (11 - bit_offset))) & 0x1f))
+                }
+            }
+        } else {
+            None
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) { (self.len(), Some(self.len())) }
+}
+
+impl<I> ExactSizeIterator for ByteToFeIter<I>
+where
+    I: ExactSizeIterator + FusedIterator + Iterator<Item = u8>,
+{
+    fn len(&self) -> usize {
+        let bytes_len = self.iter.len() + 1; // +1 because we set last_byte with call to `next`.
+        bytes_len_to_fes_len(bytes_len)
+    }
+}
+
+impl<I> FusedIterator for ByteToFeIter<I> where
+    I: ExactSizeIterator + FusedIterator + Iterator<Item = u8>
+{
+}
+
+/// Extension trait for field element iterators
+pub trait Fe32IterExt: Sized + ExactSizeIterator + FusedIterator + Iterator<Item = Fe32> {
+    /// Adapts the Fe32 iterator to output bytes instead.
+    ///
+    /// If the total number of bits is not a multiple of 8, any trailing bits
+    /// are simply dropped.
+    fn fes_to_bytes(mut self) -> FeToByteIter<Self> {
+        FeToByteIter { last_fe: self.next(), bit_offset: 0, iter: self }
+    }
+
+    /// Adapts the Fe32 iterator by prepending `fe` (witness version).
+    ///
+    /// Accepts any `Fe32`, does no checks on the validity of `witness_version`.
+    fn with_witness_version(self, witness_version: Fe32) -> WitnessVersionIter<Self> {
+        WitnessVersionIter { witness_version: Some(witness_version), iter: self }
+    }
+
+    /// Adapts the Fe32 iterator to append a checksum to the end of the data.
+    ///
+    /// Because the HRP of a bech32 string needs to be expanded before being
+    /// checksummed, this iterator is a little bit inconvenient to use on raw
+    /// data. The [`ChecksumIter::with_checksummed_hrp`] methods may be of use.
+    fn checksum<Ck: Checksum>(self) -> ChecksumIter<Self, Ck> {
+        ChecksumIter {
+            iter: self,
+            checksum_remaining: Ck::CHECKSUM_LENGTH,
+            checksum_engine: checksum::Engine::new(),
+        }
+    }
+
+    /// Adapts the Fe32 iterator to output characters using `hrp` for the human-readable part.
+    ///
+    /// Note, `hrp` is expected to be the same as that fed into the checksum engine with
+    /// `with_checksummed_hrp`.
+    fn hrp_char(self, hrp: &Hrp) -> HrpCharIter<'_, Self> {
+        HrpCharIter { hrp_iter: hrp.lowercase_char_iter(), fe_iter: self, hrp_done: false }
+    }
+}
+impl<I> Fe32IterExt for I where I: ExactSizeIterator + FusedIterator + Iterator<Item = Fe32> {}
+
+/// Iterator adaptor that converts GF32 elements to bytes. If the total number
+/// of bits is not a multiple of 8, any trailing bits are dropped.
+///
+/// Note that if there are 5 or more trailing bits, the result will be that
+/// an entire field element is dropped. If this occurs, the input was an
+/// invalid length for a bech32 string, but this iterator does not do any
+/// checks for this.
+#[derive(Clone, PartialEq, Eq)]
+pub struct FeToByteIter<I: ExactSizeIterator + FusedIterator + Iterator<Item = Fe32>> {
+    last_fe: Option<Fe32>,
+    bit_offset: usize,
+    iter: I,
+}
+
+impl<I> Iterator for FeToByteIter<I>
+where
+    I: ExactSizeIterator + FusedIterator + Iterator<Item = Fe32>,
+{
+    type Item = u8;
+    fn next(&mut self) -> Option<u8> {
+        let bit_offset = {
+            let ret = self.bit_offset;
+            self.bit_offset = (self.bit_offset + 8) % 5;
+            ret
+        };
+
+        if let Some(last) = self.last_fe {
+            let mut ret = last.0 << (3 + bit_offset);
+
+            self.last_fe = self.iter.next();
+            let next1 = self.last_fe?;
+            if bit_offset > 2 {
+                self.last_fe = self.iter.next();
+                let next2 = self.last_fe?;
+                ret |= next1.0 << (bit_offset - 2);
+                ret |= next2.0 >> (7 - bit_offset);
+            } else {
+                ret |= next1.0 >> (2 - bit_offset);
+                if self.bit_offset == 0 {
+                    self.last_fe = self.iter.next();
+                }
+            }
+
+            Some(ret)
+        } else {
+            None
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) { (self.len(), Some(self.len())) }
+}
+
+impl<I> ExactSizeIterator for FeToByteIter<I>
+where
+    I: ExactSizeIterator + FusedIterator + Iterator<Item = Fe32>,
+{
+    fn len(&self) -> usize {
+        let fes_len = self.iter.len();
+        fes_len_to_bytes_len(fes_len)
+    }
+}
+
+impl<I> FusedIterator for FeToByteIter<I> where
+    I: ExactSizeIterator + FusedIterator + Iterator<Item = Fe32>
+{
+}
+
+/// Iterator adaptor that just prepends a single character to a field element stream.
+///
+/// More ergonomic to use than `std::iter::once(fe).chain(iter)`.
+pub struct WitnessVersionIter<I>
+where
+    I: ExactSizeIterator + FusedIterator + Iterator<Item = Fe32>,
+{
+    witness_version: Option<Fe32>,
+    iter: I,
+}
+
+impl<I> Iterator for WitnessVersionIter<I>
+where
+    I: ExactSizeIterator + FusedIterator + Iterator<Item = Fe32>,
+{
+    type Item = Fe32;
+
+    fn next(&mut self) -> Option<Fe32> { self.witness_version.take().or_else(|| self.iter.next()) }
+
+    fn size_hint(&self) -> (usize, Option<usize>) { (self.len(), Some(self.len())) }
+}
+
+impl<I> ExactSizeIterator for WitnessVersionIter<I>
+where
+    I: ExactSizeIterator + FusedIterator + Iterator<Item = Fe32>,
+{
+    fn len(&self) -> usize {
+        match self.witness_version {
+            None => self.iter.len(),
+            Some(_) => self.iter.len() + 1,
+        }
+    }
+}
+
+impl<I> FusedIterator for WitnessVersionIter<I> where
+    I: ExactSizeIterator + FusedIterator + Iterator<Item = Fe32>
+{
+}
+
+/// Iterator adaptor for field-element-yielding iterator, which tacks a
+/// checksum onto the end of the yielded data.
+#[derive(Clone, PartialEq, Eq)]
+pub struct ChecksumIter<I, Ck>
+where
+    I: ExactSizeIterator + FusedIterator + Iterator<Item = Fe32>,
+    Ck: Checksum,
+{
+    iter: I,
+    checksum_remaining: usize,
+    checksum_engine: checksum::Engine<Ck>,
+}
+
+impl<I, Ck> ChecksumIter<I, Ck>
+where
+    I: ExactSizeIterator + FusedIterator + Iterator<Item = Fe32>,
+    Ck: Checksum,
+{
+    /// Helper function to input an HRP into the underlying checksum engine of the iterator.
+    ///
+    /// This function is infallible, but if you feed it a non-ASCII `hrp` it probably
+    /// will cause your checksum engine to produce useless results.
+    pub fn with_checksummed_hrp(mut self, hrp: &Hrp) -> Self {
+        self.checksum_engine.input_hrp(hrp);
+        self
+    }
+
+    /// Helper function to input an extra field element into the underling
+    /// checksum engine of the iterator.
+    pub fn with_checksummed_fe(mut self, fe: Fe32) -> Self {
+        self.checksum_engine.input_fe(fe);
+        self
+    }
+}
+
+impl<I, Ck> Iterator for ChecksumIter<I, Ck>
+where
+    I: ExactSizeIterator + FusedIterator + Iterator<Item = Fe32>,
+    Ck: Checksum,
+{
+    type Item = Fe32;
+
+    fn next(&mut self) -> Option<Fe32> {
+        match self.iter.next() {
+            Some(fe) => {
+                self.checksum_engine.input_fe(fe);
+                Some(fe)
+            }
+            None =>
+                if self.checksum_remaining == 0 {
+                    None
+                } else {
+                    if self.checksum_remaining == Ck::CHECKSUM_LENGTH {
+                        self.checksum_engine.input_target_residue();
+                    }
+                    self.checksum_remaining -= 1;
+                    Some(Fe32(self.checksum_engine.residue().unpack(self.checksum_remaining)))
+                },
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) { (self.len(), Some(self.len())) }
+}
+
+impl<I, Ck> ExactSizeIterator for ChecksumIter<I, Ck>
+where
+    I: ExactSizeIterator + FusedIterator + Iterator<Item = Fe32>,
+    Ck: Checksum,
+{
+    fn len(&self) -> usize { self.iter.len() + Ck::CHECKSUM_LENGTH }
+}
+
+impl<I, Ck> FusedIterator for ChecksumIter<I, Ck>
+where
+    I: ExactSizeIterator + FusedIterator + Iterator<Item = Fe32>,
+    Ck: Checksum,
+{
+}
+
+/// Iterator adaptor which takes a stream of field elements, converts it to characters prefixed by
+/// an HRP. If `fe_iter` is a checksummed iter, it is expected that the `hrp` strings are identical.
+pub struct HrpCharIter<'hrp, I>
+where
+    I: ExactSizeIterator + FusedIterator + Iterator<Item = Fe32>,
+{
+    hrp_iter: hrp::LowercaseCharIter<'hrp>,
+    fe_iter: I,
+    hrp_done: bool,
+}
+
+impl<'hrp, I> Iterator for HrpCharIter<'hrp, I>
+where
+    I: ExactSizeIterator + FusedIterator + Iterator<Item = Fe32>,
+{
+    type Item = char;
+
+    fn next(&mut self) -> Option<char> {
+        if !self.hrp_done {
+            match self.hrp_iter.next() {
+                Some(c) => return Some(c),
+                None => {
+                    self.hrp_done = true;
+                    return Some('1');
+                }
+            }
+        }
+        self.fe_iter.next().map(Fe32::to_char)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) { (self.len(), Some(self.len())) }
+}
+
+impl<'hrp, I> ExactSizeIterator for HrpCharIter<'hrp, I>
+where
+    I: ExactSizeIterator + FusedIterator + Iterator<Item = Fe32>,
+{
+    fn len(&self) -> usize {
+        self.hrp_iter.len() + 1 + self.fe_iter.len() // hrp | SEP | fes
+    }
+}
+
+impl<'hrp, I> FusedIterator for HrpCharIter<'hrp, I> where
+    I: ExactSizeIterator + FusedIterator + Iterator<Item = Fe32>
+{
+}
+
+/// Returns the number of Fe32's encoded by `n` bytes.
+fn bytes_len_to_fes_len(n: usize) -> usize {
+    let bits = n * 8;
+    if bits % 5 != 0 {
+        bits / 5 + 1 // +1 because we pad the fes.
+    } else {
+        bits / 5
+    }
+}
+
+/// Returns the number of bytes required to encode `n` Fe32's.
+///
+/// (If the total number of bits is not a multiple of 8, any trailing bits are dropped.)
+fn fes_len_to_bytes_len(n: usize) -> usize { n * 5 / 8 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Asserts two iterators are equal.
+    fn check_iter_eq<I, J, T>(mut i: I, mut j: J)
+    where
+        I: Iterator<Item = T>,
+        J: Iterator<Item = T>,
+        T: PartialEq + std::fmt::Debug,
+    {
+        loop {
+            match (i.next(), j.next()) {
+                (Some(x), Some(y)) => assert_eq!(x, y),
+                (None, Some(y)) => panic!("second iterator yielded {:?}, first iterator empty", y),
+                (Some(x), None) => panic!("first iterator yielded {:?}, second iterator empty", x),
+                (None, None) => return,
+            }
+        }
+    }
+
+    #[test]
+    fn iterator_adaptors() {
+        // This test is based on the test vector
+        // BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4: 0014751e76e8199196d454941c45d1b3a323f1433bd6
+        // from BIP-173.
+
+        // 1. Convert bytes to field elements, via iterator
+        #[rustfmt::skip]
+        let data = [
+            0x75, 0x1e, 0x76, 0xe8, 0x19, 0x91, 0x96, 0xd4,
+            0x54, 0x94, 0x1c, 0x45, 0xd1, 0xb3, 0xa3, 0x23,
+            0xf1, 0x43, 0x3b, 0xd6,
+        ];
+
+        check_iter_eq(
+            data.iter().copied().bytes_to_fes().map(Fe32::to_char),
+            "w508d6qejxtdg4y5r3zarvary0c5xw7k".chars(),
+        );
+
+        // 2. Convert field elements to bytes, via iterator
+        let char_len = "w508d6qejxtdg4y5r3zarvary0c5xw7k".len();
+        assert_eq!(data.iter().copied().bytes_to_fes().size_hint(), (char_len, Some(char_len)));
+
+        let fe_iter = "w508d6qejxtdg4y5r3zarvary0c5xw7k"
+            .bytes()
+            .map(|b| Fe32::from_char(char::from(b)).unwrap());
+
+        check_iter_eq(fe_iter.clone().fes_to_bytes(), data.iter().copied());
+
+        let iter = data.iter().copied().bytes_to_fes();
+        assert_eq!(iter.len(), char_len);
+
+        let checksummed_len = char_len + 6;
+        let iter = iter.checksum::<crate::primitives::Bech32>();
+        assert_eq!(iter.len(), checksummed_len);
+
+        let hrp = Hrp::parse_unchecked("bc");
+        // Does not add the hrp to the iterator, only adds it to the checksum engine.
+        let iter = iter.with_checksummed_hrp(&hrp);
+        assert_eq!(iter.len(), checksummed_len);
+
+        // Does not add the separator to the iterator, only adds it to the checksum engine.
+        let iter = iter.with_checksummed_fe(Fe32::Q);
+        assert_eq!(iter.len(), checksummed_len);
+
+        let iter = iter.map(Fe32::to_char);
+        assert_eq!(iter.len(), checksummed_len);
+
+        check_iter_eq(iter, "w508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4".chars());
+    }
+
+    #[test]
+    fn fes_len_to_bytes_len_multiple_of_8() {
+        let fes = vec![Fe32::Q, Fe32::Q, Fe32::Q, Fe32::Q, Fe32::Q, Fe32::Q, Fe32::Q, Fe32::Q];
+        let bytes = fes.iter().copied().fes_to_bytes().collect::<Vec<u8>>();
+
+        let got = fes_len_to_bytes_len(fes.len());
+        let want = bytes.len();
+
+        assert_eq!(want, 5); // Sanity check.
+        assert_eq!(got, want);
+
+        assert_eq!(bytes.len(), fes_len_to_bytes_len(fes.len()));
+    }
+
+    #[test]
+    fn fes_len_to_bytes_len_pad_one_bit() {
+        let fes = vec![Fe32::Q, Fe32::Q, Fe32::Q];
+        let bytes = fes.iter().copied().fes_to_bytes().collect::<Vec<u8>>();
+
+        let got = fes_len_to_bytes_len(fes.len());
+        let want = bytes.len();
+
+        assert_eq!(want, 1); // Sanity check.
+        assert_eq!(got, want);
+    }
+
+    #[test]
+    fn fes_len_to_bytes_len_pad_six_bits() {
+        let fes = vec![Fe32::Q, Fe32::Q];
+        let bytes = fes.iter().copied().fes_to_bytes().collect::<Vec<u8>>();
+
+        let got = fes_len_to_bytes_len(fes.len());
+        let want = bytes.len();
+
+        assert_eq!(want, 1); // Sanity check.
+        assert_eq!(got, want);
+    }
+
+    #[test]
+    fn bytes_len_to_fes_len_multiple_of_5() {
+        let bytes = vec![0x01, 0x02, 0x03, 0x05, 0x05]; // 5 bytes of arbitary data.
+        let fes = bytes.iter().copied().bytes_to_fes().collect::<Vec<Fe32>>();
+
+        let got = bytes_len_to_fes_len(bytes.len());
+        let want = fes.len();
+
+        assert_eq!(want, 8); // Sanity check.
+        assert_eq!(got, want);
+    }
+
+    #[test]
+    fn bytes_len_to_fes_len_extra_bit_is_dropped() {
+        let bytes = vec![0x01, 0x02]; // 2 bytes of arbitary data.
+        let fes = bytes.iter().copied().bytes_to_fes().collect::<Vec<Fe32>>();
+
+        let got = bytes_len_to_fes_len(bytes.len());
+        let want = fes.len();
+
+        assert_eq!(want, 4); // Sanity check.
+        assert_eq!(got, want);
+    }
+
+    #[test]
+    fn bytes_len_to_fes_len_extra_4_bits_are_dropped() {
+        let bytes = vec![0x01, 0x02, 0x03]; // 3 bytes of arbitary data.
+        let fes = bytes.iter().copied().bytes_to_fes().collect::<Vec<Fe32>>();
+
+        let got = bytes_len_to_fes_len(bytes.len());
+        let want = fes.len();
+
+        assert_eq!(want, 5); // Sanity check.
+        assert_eq!(got, want);
+    }
+}

--- a/src/primitives/mod.rs
+++ b/src/primitives/mod.rs
@@ -5,8 +5,65 @@
 //!
 //! ## Overview
 //!
-//! - `gf32`: GF32 elements, i.e. "bech32 characters".
-//! - `hrp`: human-readable part.
+//! - [checksum](checksum): Generic degree-2 BCH code checksum generation and locating, including
+//!   traits for people to define their own correction (error location and correction).
+//! - [gf32](gf32): GF32 elements, i.e. "bech32 characters".
+//! - [hrp](hrp): The human-readable part of a bech32 string.
+//! - [iter](iter): Iterator adaptors for no-alloc access to the bech32 string and its parts as well
+//!   as conversion to/from u5/u8.
 
+pub mod checksum;
 pub mod gf32;
 pub mod hrp;
+pub mod iter;
+
+use checksum::{Checksum, PackedNull};
+
+/// The "null checksum" used on bech32 strings for which we want to do no checksum checking.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum NoChecksum {}
+
+/// The bech32 checksum algorithm, defined in [BIP-173].
+/// [BIP-173]: <https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki>
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Bech32 {}
+
+/// The bech32m checksum algorithm, defined in [BIP-350].
+/// [BIP-350]: <https://github.com/bitcoin/bips/blob/master/bip-0359.mediawiki>
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Bech32m {}
+
+impl Checksum for NoChecksum {
+    type MidstateRepr = PackedNull;
+    const CHECKSUM_LENGTH: usize = 0;
+    const GENERATOR_SH: [PackedNull; 5] = [PackedNull; 5];
+    const TARGET_RESIDUE: PackedNull = PackedNull;
+}
+
+// Bech32[m] generator coefficients, copied from Bitcoin Core src/bech32.cpp
+const GEN: [u32; 5] = [0x3b6a_57b2, 0x2650_8e6d, 0x1ea1_19fa, 0x3d42_33dd, 0x2a14_62b3];
+
+impl Checksum for Bech32 {
+    type MidstateRepr = u32;
+    const CHECKSUM_LENGTH: usize = 6;
+    const GENERATOR_SH: [u32; 5] = GEN;
+    const TARGET_RESIDUE: u32 = 1;
+}
+// Same as Bech32 except TARGET_RESIDUE is different
+impl Checksum for Bech32m {
+    type MidstateRepr = u32;
+    const CHECKSUM_LENGTH: usize = 6;
+    const GENERATOR_SH: [u32; 5] = GEN;
+    const TARGET_RESIDUE: u32 = 0x2bc830a3;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bech32_sanity() { Bech32::sanity_check(); }
+
+    #[test]
+    fn bech32m_sanity() { Bech32m::sanity_check(); }
+}


### PR DESCRIPTION
Add, as yet unused, modules that implement BCH codes and iterators (used for no-alloc access to the bech32 string parts).

Draft because I cannot work out a nice next step. 

I've spent two good chunks of time today and yesterday and I'm stumped how to proceed. Sorry for the Wall Of Text.

1. We cannot use the iterators to implement current traits/types in `lib.rs` because of the use of `AsRef<[u8]>`, which is not compatible with the iterators because we require `ExactSizedIterator`.
2. I'm confused as to what abstraction we are aiming for for this crate
   1. is it a general purpose bech32 crate
   2. is it specifically there to support the `rust-bitcoin` crate i.e., layer one bitcoin
  
  If its (i) then I don't even know what this means, my whole understanding of the crate is based solely on the two bips. If it is (ii) then I don't know how to do a simple-next-step without just re-writing the whole API.

### More points on the abstraction
1. What goes in this crate vs in the `bitcoin::address` module (e.g. who knows about "bc", "tb", "bcrt", valid witness versions, valid witness program length)?
2. Why does `rust-bech32-bitcoin` exist and is the abstraction implied by its existence valid (I know you already said forget about that crate @apoelstra but it effects the abstraction discussion IMO)?


### Moving Forward

1. Can we just clobber the whole API (`lib.rs`) and write an API tailored to bitcoin layer one and let other users just go to `primitives` and use the more clunky but fully functional API?
2. Do we need to just add a `segwit` module that implements the API in (1) and leave `lib.rs` as it is?

If (1) we need buyin from @clarkmoody because its his crate but also because he understands who else is using the crate.
If (2) I have no idea how we ever stabalize the crate because no one in rust-bitcoin will sign off on it.