### PR TITLE
Reduce noise in HTML docs

### DIFF
--- a/src/primitives/mod.rs
+++ b/src/primitives/mod.rs
@@ -2,11 +2,6 @@
 // SPDX-License-Identifier: MIT
 
 //! Provides the internal nuts and bolts that enable bech32 encoding/decoding.
-//!
-//! ## Overview
-//!
-//! - `gf32`: GF32 elements, i.e. "bech32 characters".
-//! - `hrp`: human-readable part.
 
 pub mod gf32;
 pub mod hrp;


### PR DESCRIPTION
The "overview" in `primitives::mod` causes the same info to be displayed twice in the HTML rendering of our docs. Just remove it.