### PR TITLE
Remove unnecessary attribution

### DIFF
--- a/src/primitives/gf32.rs
+++ b/src/primitives/gf32.rs
@@ -1,5 +1,3 @@
-// Written by the Andrew Poelstra and the rust-bitcoin developers.
-// (Replacing very similar code originally written by Clark Moody.)
 // SPDX-License-Identifier: MIT
 
 //! GF32 - Galois Field over 32 elements.

--- a/src/primitives/mod.rs
+++ b/src/primitives/mod.rs
@@ -1,4 +1,3 @@
-// Written by the rust-bitcoin developers.
 // SPDX-License-Identifier: MIT
 
 //! Provides the internal nuts and bolts that enable bech32 encoding/decoding.


### PR DESCRIPTION
As we discussed in rust-bitcoin recently the "written by" attribute is not that valuable because:

- It is not really true because many devs contribute to a file
- The 'by rust bitcoin devs' adds zero information

Remove the unnecessary attribution for all files in the `primitives` module. Leave the `lib.rs` attribution as
```
    // Written by Clark Moody and the rust-bitcoin developers.
```
because Clark wrote the library initially and the rust-bitcoin devs came along and hacked the s**t out of it, keep the attribution to give recognition to Clark and to assume accountability by the rust-bitcoin devs (well that's how I read it anyways).