### PR TITLE
Add checksum module

### DIFF
--- a/src/primitives/checksum.rs
+++ b/src/primitives/checksum.rs
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: MIT
+
+//! Degree-2 [BCH] code checksum.
+//!
+//! [BCH]: <https://en.wikipedia.org/wiki/BCH_code>
+
+use core::{mem, ops};
+
+use crate::primitives::gf32::Fe32;
+use crate::primitives::hrp::Hrp;
+
+/// Trait defining a particular checksum.
+///
+/// For users, this can be treated as a marker trait; none of the associated data
+/// are end-user relevant.
+pub trait Checksum {
+    /// An unsigned integer type capable of holding a packed version of the generator
+    /// polynomial (without its leading 1) and target residue (which will have the
+    /// same width).
+    ///
+    /// Generally, this is the number of characters in the checksum times 5. So e.g.
+    /// for bech32, which has a 6-character checksum, we need 30 bits, so we can use
+    /// u32 here.
+    ///
+    /// The smallest type possible should be used, for efficiency reasons, but the
+    /// only operations we do on these types are bitwise xor and shifts, so it should
+    /// be pretty efficient no matter what.
+    type MidstateRepr: PackedFe32;
+
+    /// The number of characters in the checksum.
+    ///
+    /// Alternately, the degree of the generator polynomial. This is **not** the same
+    /// as the "length of the code", which is the maximum number of characters that
+    /// the checksum can usefully cover.
+    const CHECKSUM_LENGTH: usize;
+
+    /// The coefficients of the generator polynomial, except the leading monic term,
+    /// in "big-endian" (highest-degree coefficients get leftmost bits) order, along
+    /// with the 4 shifts of the generator.
+    ///
+    /// The shifts are literally the generator polynomial left-shifted (i.e. multiplied
+    /// by the appropriate power of 2) in the field. That is, the 5 entries in this
+    /// array are the generator times { P, Z, Y, G, S } in that order.
+    ///
+    /// These cannot be usefully pre-computed because of Rust's limited constfn support
+    /// as of 1.67, so they must be specified manually for each checksum. To check the
+    /// values for consistency, run `Self::sanity_check()`.
+    const GENERATOR_SH: [Self::MidstateRepr; 5];
+
+    /// The residue, modulo the generator polynomial, that a valid codeword will have.
+    const TARGET_RESIDUE: Self::MidstateRepr;
+
+    /// Sanity checks that the various constants of the trait are set in a way that they
+    /// are consistent with each other.
+    ///
+    /// This function never needs to be called by users, but anyone defining a checksum
+    /// should add a unit test to their codebase which calls this.
+    fn sanity_check() {
+        // Check that the declared midstate type can actually hold the whole checksum.
+        assert!(Self::CHECKSUM_LENGTH <= Self::MidstateRepr::WIDTH);
+
+        // Check that the provided generator polynomials are, indeed, the same polynomial just shifted.
+        for i in 1..5 {
+            for j in 0..Self::MidstateRepr::WIDTH {
+                let last = Self::GENERATOR_SH[i - 1].unpack(j);
+                let curr = Self::GENERATOR_SH[i].unpack(j);
+                // GF32 is defined by extending GF2 with a root of x^5 + x^3 + 1 = 0
+                // which when written as bit coefficients is 41 = 0. Hence xoring
+                // (adding, in GF32) by 41 is the way to reduce x^5.
+                assert_eq!(
+                    curr,
+                    (last << 1) ^ if last & 0x10 == 0x10 { 41 } else { 0 },
+                    "Element {} of generator << 2^{} was incorrectly computed. (Should have been {} << 1)",
+                    j, i, last,
+                );
+            }
+        }
+    }
+}
+
+/// A checksum engine, which can be used to compute or verify a checksum.
+///
+/// Use this to verify a checksum, feed it the data to be checksummed using
+/// the `Self::input_*` methods.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct Engine<Ck: Checksum> {
+    residue: Ck::MidstateRepr,
+}
+
+impl<Ck: Checksum> Default for Engine<Ck> {
+    fn default() -> Self { Self::new() }
+}
+
+impl<Ck: Checksum> Engine<Ck> {
+    /// Constructs a new checksum engine with no data input.
+    pub fn new() -> Self { Engine { residue: Ck::MidstateRepr::ONE } }
+
+    /// Feeds `hrp` into the checksum engine.
+    pub fn input_hrp(&mut self, hrp: &Hrp) {
+        for b in hrp.lowercase_byte_iter() {
+            self.input_fe(Fe32(b >> 5));
+        }
+        self.input_fe(Fe32::Q);
+        for b in hrp.lowercase_byte_iter() {
+            self.input_fe(Fe32(b & 0x1f));
+        }
+    }
+
+    /// Adds a single gf32 element to the checksum engine.
+    ///
+    /// This is where the actual checksum computation magic happens.
+    pub fn input_fe(&mut self, e: Fe32) {
+        let xn = self.residue.mul_by_x_then_add(Ck::CHECKSUM_LENGTH, e.into());
+        for i in 0..5 {
+            if xn & (1 << i) != 0 {
+                self.residue = self.residue ^ Ck::GENERATOR_SH[i];
+            }
+        }
+    }
+
+    /// Inputs the target residue of the checksum.
+    ///
+    /// Checksums are generated by appending the target residue to the input
+    /// string, then computing the actual residue, and then replacing the
+    /// target with the actual. This method lets us compute the actual residue
+    /// without doing any string concatenations.
+    pub fn input_target_residue(&mut self) {
+        for i in 0..Ck::CHECKSUM_LENGTH {
+            self.input_fe(Fe32(Ck::TARGET_RESIDUE.unpack(Ck::CHECKSUM_LENGTH - i - 1)));
+        }
+    }
+
+    /// Returns for the current checksum residue.
+    pub fn residue(&self) -> &Ck::MidstateRepr { &self.residue }
+}
+
+/// Trait describing an integer type which can be used as a "packed" sequence of Fe32s.
+///
+/// This is implemented for u32, u64 and u128, as a way to treat these primitive types as
+/// packed coefficients of polynomials over GF32 (up to some maximal degree, of course).
+///
+/// This is useful because then multiplication by x reduces to simply left-shifting by 5,
+/// and addition of entire polynomials can be done by xor.
+pub trait PackedFe32: Copy + PartialEq + Eq + ops::BitXor<Self, Output = Self> {
+    /// The one constant, for which stdlib provides no existing trait.
+    const ONE: Self;
+
+    /// The number of fe32s that can fit into the type; computed as floor(bitwidth / 5).
+    const WIDTH: usize = mem::size_of::<Self>() * 8 / 5;
+
+    /// Extracts the coefficient of the x^n from the packed polynomial.
+    fn unpack(&self, n: usize) -> u8;
+
+    /// Multiply the polynomial by x, drop its highest coefficient (and return it), and
+    /// add a new field element to the now-0 constant coefficient.
+    ///
+    /// Takes the degree of the polynomial as an input; for checksum applications
+    /// this shoud basically always be `Checksum::CHECKSUM_WIDTH`.
+    fn mul_by_x_then_add(&mut self, degree: usize, add: u8) -> u8;
+}
+
+/// A placeholder type used as part of the [`crate::primitives::NoChecksum`] "checksum".
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct PackedNull;
+
+impl ops::BitXor<PackedNull> for PackedNull {
+    type Output = PackedNull;
+    fn bitxor(self, _: PackedNull) -> PackedNull { PackedNull }
+}
+
+impl PackedFe32 for PackedNull {
+    const ONE: Self = PackedNull;
+    fn unpack(&self, _: usize) -> u8 { 0 }
+    fn mul_by_x_then_add(&mut self, _: usize, _: u8) -> u8 { 0 }
+}
+
+macro_rules! impl_packed_fe32 {
+    ($ty:ident) => {
+        impl PackedFe32 for $ty {
+            const ONE: Self = 1;
+
+            fn unpack(&self, n: usize) -> u8 {
+                debug_assert!(n < Self::WIDTH);
+                (*self >> (n * 5)) as u8 & 0x1f
+            }
+
+            fn mul_by_x_then_add(&mut self, degree: usize, add: u8) -> u8 {
+                debug_assert!(degree > 0);
+                debug_assert!(degree <= Self::WIDTH);
+                debug_assert!(add < 32);
+                let ret = self.unpack(degree - 1);
+                *self &= !(0x1f << ((degree - 1) * 5));
+                *self <<= 5;
+                *self |= Self::from(add);
+                ret
+            }
+        }
+    };
+}
+impl_packed_fe32!(u32);
+impl_packed_fe32!(u64);
+impl_packed_fe32!(u128);

--- a/src/primitives/mod.rs
+++ b/src/primitives/mod.rs
@@ -8,5 +8,57 @@
 //! - `gf32`: GF32 elements, i.e. "bech32 characters".
 //! - `hrp`: human-readable part.
 
+pub mod checksum;
 pub mod gf32;
 pub mod hrp;
+
+use checksum::{Checksum, PackedNull};
+
+/// The "null checksum" used on bech32 strings for which we want to do no checksum checking.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum NoChecksum {}
+
+/// The bech32 checksum algorithm, defined in [BIP-173].
+/// [BIP-173]: <https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki>
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Bech32 {}
+
+/// The bech32m checksum algorithm, defined in [BIP-350].
+/// [BIP-350]: <https://github.com/bitcoin/bips/blob/master/bip-0359.mediawiki>
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Bech32m {}
+
+impl Checksum for NoChecksum {
+    type MidstateRepr = PackedNull;
+    const CHECKSUM_LENGTH: usize = 0;
+    const GENERATOR_SH: [PackedNull; 5] = [PackedNull; 5];
+    const TARGET_RESIDUE: PackedNull = PackedNull;
+}
+
+// Bech32[m] generator coefficients, copied from Bitcoin Core src/bech32.cpp
+const GEN: [u32; 5] = [0x3b6a_57b2, 0x2650_8e6d, 0x1ea1_19fa, 0x3d42_33dd, 0x2a14_62b3];
+
+impl Checksum for Bech32 {
+    type MidstateRepr = u32;
+    const CHECKSUM_LENGTH: usize = 6;
+    const GENERATOR_SH: [u32; 5] = GEN;
+    const TARGET_RESIDUE: u32 = 1;
+}
+// Same as Bech32 except TARGET_RESIDUE is different
+impl Checksum for Bech32m {
+    type MidstateRepr = u32;
+    const CHECKSUM_LENGTH: usize = 6;
+    const GENERATOR_SH: [u32; 5] = GEN;
+    const TARGET_RESIDUE: u32 = 0x2bc830a3;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bech32_sanity() { Bech32::sanity_check(); }
+
+    #[test]
+    fn bech32m_sanity() { Bech32m::sanity_check(); }
+}


### PR DESCRIPTION
Add a module `checksum` that implements BCH codes. Use the new module in place of the current checksum logic within the `Bech32Writer`.

Please note, this PR does not remove _all_ the checksum related logic from `lib.rs` - checksum verification is still present. Will attempt that if this merges.