### PR TITLE
Make Bech32Writer constructor public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,7 @@ impl<'a, Ck: Checksum> Bech32Writer<'a, Ck> {
     ///
     /// This is a rather low-level API and doesn't check the HRP or data length for standard
     /// compliance.
-    fn new(hrp: Hrp, fmt: &'a mut dyn fmt::Write) -> Result<Bech32Writer<'a, Ck>, fmt::Error> {
+    pub fn new(hrp: Hrp, fmt: &'a mut dyn fmt::Write) -> Result<Bech32Writer<'a, Ck>, fmt::Error> {
         let mut engine = checksum::Engine::new();
         engine.input_hrp(&hrp);
 


### PR DESCRIPTION
During comit `10e32e91 Add checksum module` I somehow made the constructor private, this is clearly incorrect. Revert the change by making the constructor public again.