### PR TITLE
WIP: Add `hrpstring` module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,5 @@ default = ["std"]
 std = ["alloc"]
 alloc = []
 
-[dependencies.arrayvec]
-version = "0.7.1"
-default-features = false
-optional = true
-
 [target.'cfg(mutate)'.dev-dependencies]
 mutagen = { git = "https://github.com/llogiq/mutagen" }

--- a/embedded/no-allocator/src/main.rs
+++ b/embedded/no-allocator/src/main.rs
@@ -26,9 +26,7 @@ fn main() -> ! {
 
     let hrp = Hrp::parse("bech32").unwrap();
 
-    bech32::encode_to_fmt(&mut encoded, hrp, &base32, Variant::Bech32)
-        .unwrap()
-        .unwrap();
+    bech32::encode_to_fmt(&mut encoded, hrp, &base32, Variant::Bech32).unwrap();
     test(&*encoded == "bech321qqqsyrhqy2a");
 
     hprintln!("{}", encoded).unwrap();

--- a/embedded/no-allocator/src/main.rs
+++ b/embedded/no-allocator/src/main.rs
@@ -26,7 +26,7 @@ fn main() -> ! {
 
     let hrp = Hrp::parse("bech32").unwrap();
 
-    bech32::encode_to_fmt_anycase(&mut encoded, hrp, &base32, Variant::Bech32)
+    bech32::encode_to_fmt(&mut encoded, hrp, &base32, Variant::Bech32)
         .unwrap()
         .unwrap();
     test(&*encoded == "bech321qqqsyrhqy2a");

--- a/embedded/with-allocator/src/main.rs
+++ b/embedded/with-allocator/src/main.rs
@@ -11,7 +11,8 @@ use self::alloc::vec::Vec;
 use core::alloc::Layout;
 
 use alloc_cortex_m::CortexMHeap;
-use bech32::{self, FromBase32, ToBase32, Variant, Hrp};
+use bech32::{self, u5, Variant, Hrp};
+use bech32::primitives::iter::{Fe32IterExt, ByteIterExt};
 use cortex_m::asm;
 use cortex_m_rt::entry;
 use cortex_m_semihosting::{debug, hprintln};
@@ -27,9 +28,11 @@ fn main() -> ! {
     unsafe { ALLOCATOR.init(cortex_m_rt::heap_start() as usize, HEAP_SIZE) }
 
     let hrp = Hrp::parse("bech32").unwrap();
+    let data = [0x00u8, 0x01, 0x02].iter().copied().bytes_to_fes().collect::<Vec<u5>>();
+
     let encoded = bech32::encode(
         hrp,
-        vec![0x00, 0x01, 0x02].to_base32(),
+        data,
         Variant::Bech32,
     );
     test(encoded == "bech321qqqsyrhqy2a".to_string());
@@ -37,8 +40,10 @@ fn main() -> ! {
     hprintln!("{}", encoded).unwrap();
 
     let (got_hrp, data, variant) = bech32::decode(&encoded).unwrap();
+    let data = data.iter().copied().fes_to_bytes().collect::<Vec<u8>>();
+
     test(got_hrp == hrp);
-    test(Vec::<u8>::from_base32(&data).unwrap() == vec![0x00, 0x01, 0x02]);
+    test(data == vec![0x00, 0x01, 0x02]);
     test(variant == Variant::Bech32);
 
     debug::exit(debug::EXIT_SUCCESS);

--- a/embedded/with-allocator/src/main.rs
+++ b/embedded/with-allocator/src/main.rs
@@ -31,8 +31,7 @@ fn main() -> ! {
         hrp,
         vec![0x00, 0x01, 0x02].to_base32(),
         Variant::Bech32,
-    )
-    .unwrap();
+    );
     test(encoded == "bech321qqqsyrhqy2a".to_string());
 
     hprintln!("{}", encoded).unwrap();

--- a/fuzz/fuzz_targets/decode_rnd.rs
+++ b/fuzz/fuzz_targets/decode_rnd.rs
@@ -8,7 +8,7 @@ fn do_test(data: &[u8]) {
         Err(_) => return,
     };
 
-    assert_eq!(bech32::encode(b32.0, b32.1, b32.2).unwrap(), data_str);
+    assert_eq!(bech32::encode(b32.0, b32.1, b32.2), data_str);
 }
 
 #[cfg(feature = "afl")]

--- a/fuzz/fuzz_targets/encode_decode.rs
+++ b/fuzz/fuzz_targets/encode_decode.rs
@@ -33,12 +33,11 @@ fn do_test(data: &[u8]) {
             match Hrp::parse(&s) {
                 Err(_) => return,
                 Ok(hrp) => {
-                    if let Ok(data_str) = bech32::encode(hrp, &dp, variant).map(|b32| b32.to_string()) {
-                        let decoded = bech32::decode(&data_str);
-                        let b32 = decoded.expect("should be able to decode own encoding");
+                    let encoded = bech32::encode(hrp, &dp, variant);
+                    let decoded = bech32::decode(&encoded);
+                    let b32 = decoded.expect("should be able to decode own encoding");
 
-                        assert_eq!(bech32::encode(b32.0, &b32.1, b32.2).unwrap(), data_str);
-                    }
+                    assert_eq!(bech32::encode(b32.0, &b32.1, b32.2), encoded);
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -438,44 +438,6 @@ pub fn encode_to_fmt<T: AsRef<[u5]>>(
     Ok(Ok(()))
 }
 
-/// Encode a bech32 payload to an [fmt::Write], but with any case.
-/// This method is intended for implementing traits from [core::fmt] without [std].
-///
-/// See `encode_to_fmt` for meaning of errors.
-pub fn encode_to_fmt_anycase<T: AsRef<[u5]>>(
-    fmt: &mut dyn fmt::Write,
-    hrp: Hrp,
-    data: T,
-    variant: Variant,
-) -> Result<fmt::Result, Error> {
-    match variant {
-        Variant::Bech32 => {
-            let res = Bech32Writer::<Bech32>::new(hrp, fmt);
-            match res {
-                Ok(mut writer) => {
-                    Ok(writer.write(data.as_ref()).and_then(|_| {
-                        // Finalize manually to avoid panic on drop if write fails
-                        writer.finalize()
-                    }))
-                }
-                Err(e) => Ok(Err(e)),
-            }
-        }
-        Variant::Bech32m => {
-            let res = Bech32Writer::<Bech32m>::new(hrp, fmt);
-            match res {
-                Ok(mut writer) => {
-                    Ok(writer.write(data.as_ref()).and_then(|_| {
-                        // Finalize manually to avoid panic on drop if write fails
-                        writer.finalize()
-                    }))
-                }
-                Err(e) => Ok(Err(e)),
-            }
-        }
-    }
-}
-
 /// Encodes a bech32 payload without a checksum to a writer ([`fmt::Write`]).
 ///
 /// This method is intended for implementing traits from [`std::fmt`].
@@ -1221,7 +1183,7 @@ mod tests {
         [0x00u8, 0x01, 0x02].write_base32(&mut base32).unwrap();
 
         let bech32_hrp = Hrp::parse("bech32").expect("bech32 is valid");
-        encode_to_fmt_anycase(&mut encoded, bech32_hrp, &base32, Variant::Bech32).unwrap().unwrap();
+        encode_to_fmt(&mut encoded, bech32_hrp, &base32, Variant::Bech32).unwrap().unwrap();
         assert_eq!(&*encoded, "bech321qqqsyrhqy2a");
 
         println!("{}", encoded);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,7 @@ impl<'a, Ck: Checksum> Bech32Writer<'a, Ck> {
     ///
     /// This is a rather low-level API and doesn't check the HRP or data length for standard
     /// compliance.
-    fn new(hrp: Hrp, fmt: &'a mut dyn fmt::Write) -> Result<Bech32Writer<'a, Ck>, fmt::Error> {
+    pub fn new(hrp: Hrp, fmt: &'a mut dyn fmt::Write) -> Result<Bech32Writer<'a, Ck>, fmt::Error> {
         let mut engine = checksum::Engine::new();
         engine.input_hrp(&hrp);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -372,9 +372,8 @@ pub fn encode_to_fmt<T: AsRef<[u5]>>(
 ///
 /// This method is intended for implementing traits from [`std::fmt`].
 ///
-/// # Errors
+/// # Deviations from standard.
 ///
-/// * Deviations from standard.
 /// * No length limits are enforced for the data part.
 pub fn encode_without_checksum_to_fmt<T: AsRef<[u5]>>(
     fmt: &mut dyn fmt::Write,
@@ -422,9 +421,8 @@ impl Variant {
 
 /// Encodes a bech32 payload to string.
 ///
-/// # Errors
+/// # Deviations from standard.
 ///
-/// * Deviations from standard.
 /// * No length limits are enforced for the data part.
 #[cfg(feature = "alloc")]
 pub fn encode<T: AsRef<[u5]>>(hrp: Hrp, data: T, variant: Variant) -> String {
@@ -452,9 +450,8 @@ pub fn encode<T: AsRef<[u5]>>(hrp: Hrp, data: T, variant: Variant) -> String {
 
 /// Encodes a bech32 payload to string without the checksum.
 ///
-/// # Errors
+/// # Deviations from standard.
 ///
-/// * Deviations from standard.
 /// * No length limits are enforced for the data part.
 #[cfg(feature = "alloc")]
 pub fn encode_without_checksum<T: AsRef<[u5]>>(hrp: Hrp, data: T) -> Result<String, Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,24 +11,6 @@
 //!
 //! The original description in [BIP-0173](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki)
 //! has more details. See also [BIP-0350](https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki).
-//!
-#![cfg_attr(
-    feature = "std",
-    doc = "
-# Examples
-```
-use bech32::{self, FromBase32, ToBase32, Variant, Hrp};
-let hrp = Hrp::parse(\"bech32\").expect(\"bech32 is valid\");
-let encoded = bech32::encode(hrp, vec![0x00, 0x01, 0x02].to_base32(), Variant::Bech32);
-assert_eq!(encoded, \"bech321qqqsyrhqy2a\".to_string());
-let (hrp, data, variant) = bech32::decode(&encoded).unwrap();
-assert_eq!(hrp.to_string(), \"bech32\");
-assert_eq!(Vec::<u8>::from_base32(&data).unwrap(), vec![0x00, 0x01, 0x02]);
-assert_eq!(variant, Variant::Bech32);
-```
-"
-)]
-//!
 
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
 // Experimental features we need.

--- a/src/primitives/gf32.rs
+++ b/src/primitives/gf32.rs
@@ -183,6 +183,8 @@ impl Fe32 {
         Ok(Fe32(u5))
     }
 
+    pub(crate) fn from_char_unchecked(c: u8) -> Fe32 { Fe32(CHARS_INV[usize::from(c)] as u8) }
+
     /// Converts the field element to a lowercase bech32 character.
     pub fn to_char(self) -> char {
         // Indexing fine as we have self.0 in [0, 32) as an invariant.

--- a/src/primitives/hrp.rs
+++ b/src/primitives/hrp.rs
@@ -114,16 +114,6 @@ impl Hrp {
         Ok((new, case))
     }
 
-    /// Lowercase the inner ASCII bytes of this HRP.
-    // This is a hack to support `encode_to_fmt`, we should remove this function.
-    pub(crate) fn lowercase(&mut self) {
-        for b in self.buf.iter_mut() {
-            if is_ascii_uppercase(*b) {
-                *b |= 32;
-            }
-        }
-    }
-
     /// Returns this human-readable part as a lowercase string.
     #[cfg(feature = "alloc")]
     pub fn to_lowercase(&self) -> String { self.lowercase_char_iter().collect() }

--- a/src/primitives/hrpstring.rs
+++ b/src/primitives/hrpstring.rs
@@ -1,0 +1,407 @@
+// SPDX-License-Identifier: MIT
+
+//! String encoding/decoding of HRP strings as specified by [BIP-173] (bech32) and [BIP-350] (bech32m).
+//!
+//! HRP string format: `<hrp> 1 <witness_version> <payload> <checksum>`
+//!
+//! * **hrp**: Human Readable Part.
+//! * **witness_version**: 0 ('q) for bech32 1 ('p') for bech32m.
+//! * **payload**: GF(32) bech32 encoded characters.
+//! * **checksum**: BCH code checksum.
+//!
+//! [BIP-173]: <https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki>
+//! [BIP-350]: <https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki>
+
+#[cfg(all(feature = "alloc", not(feature = "std")))]
+use alloc::borrow::Cow;
+use core::convert::{Infallible, TryFrom};
+use core::marker::PhantomData;
+use core::{fmt, iter, slice, str};
+
+use crate::primitives::checksum::{self, Checksum};
+use crate::primitives::gf32::{self, Fe32};
+use crate::primitives::hrp::{self, Hrp};
+use crate::primitives::iter::{Fe32IterExt, FeToByteIter};
+use crate::write_err;
+
+/// Separator between the hrp and payload (as defined by BIP-173).
+const SEP: char = '1';
+
+/// An HRP string that has been parsed from an ordinary checksummed string.
+///
+/// Parsing as an HRP string does not validate the checksum in any way.
+pub struct Parsed<'s> {
+    /// The human-readable part, guaranteed to be lowercase ASCII characters.
+    hrp: Hrp,
+    /// The witness version, if one exists.
+    witness_version: Option<u8>,
+    /// The data part (including checksum, if any).
+    ///
+    /// This is ASCII byte values of the parsed string, guaranteed to be valid bech32 characters.
+    data_chk: &'s [u8],
+}
+
+impl<'s> Parsed<'s> {
+    /// Parses an HRP string, without treating the first data character specially.
+    pub fn new(s: &'s str) -> Result<Self, Error> {
+        let sep_pos = check_characters(s)?;
+        let (hrp, data) = s.split_at(sep_pos);
+
+        let p = Parsed {
+            hrp: Hrp::parse(hrp)?,
+            witness_version: None,
+            data_chk: data[1..].as_bytes(),
+        };
+        Ok(p)
+    }
+
+    /// Parses an HRP string, treating the first data character as a witness version.
+    ///
+    /// This version byte does not appear in the extracted binary data, but is covered
+    /// by the checksum. It can be accessed with [`Self::witness_version`] and is also
+    /// returned from this constructor as a convenience.
+    pub fn new_with_witness_version(s: &'s str) -> Result<(Self, u8), Error> {
+        let mut ret = Self::new(s)?;
+        if ret.data_chk.is_empty() {
+            return Err(Error::InvalidDataEmpty);
+        }
+
+        // Unwrap ok since check_characters (in `Self::new`) checked the bech32-ness of this char.
+        let witver = Fe32::from_char(ret.data_chk[0].into()).unwrap().to_u8();
+
+        ret.witness_version = Some(witver);
+        ret.data_chk = &ret.data_chk[1..];
+
+        Ok((ret, witver))
+    }
+
+    /// Helper function that sanity checks the length of an HRP string for a given checksum algorithm.
+    ///
+    /// Specifically, check that
+    ///     * the data is at least long enough to contain a checksum
+    ///     * that the length doesn't imply any "useless characters" where no bits are used
+    fn checksum_length_checks<Ck: Checksum>(&self) -> Result<(), Error> {
+        if self.data_chk.len() < Ck::CHECKSUM_LENGTH
+            || (self.data_chk.len() - Ck::CHECKSUM_LENGTH) * 5 % 8 > 4
+        {
+            return Err(Error::InvalidChecksumLength);
+        }
+        Ok(())
+    }
+
+    /// Validates that the parsed string has a correct checksum.
+    pub fn validate_checksum<Ck: Checksum>(&self) -> Result<(), Error>
+    where
+        <Ck as Checksum>::MidstateRepr: core::fmt::Display,
+    {
+        self.checksum_length_checks::<Ck>()?;
+        let mut checksum_eng = checksum::Engine::<Ck>::new();
+        checksum_eng.input_hrp(&self.hrp());
+        if let Some(witver) = self.witness_version {
+            checksum_eng.input_fe(Fe32::try_from(witver).map_err(Error::InvalidWitnessVersion)?);
+        }
+        // Unwrap ok since we checked all characters in our constructor.
+        for fe in self.data_chk.iter().map(|&b| Fe32::from_char_unchecked(b)) {
+            checksum_eng.input_fe(fe);
+        }
+        if checksum_eng.residue() == &Ck::TARGET_RESIDUE {
+            Ok(())
+        } else {
+            Err(Error::InvalidChecksum)
+        }
+    }
+
+    /// Iterate over the data encoded by the HRP string (excluding the HRP, witness
+    /// version byte if any, and checksum).
+    ///
+    /// When constructing the iterator we do some preliminary checks on the length
+    /// of the checksummed data, hence the `Result` return type. But **this function
+    /// does not validate the checksum**. Before using it, you should first call
+    /// [`Self::validate_checksum`].
+    ///
+    /// This function is generic over the checksum algorithm, but only uses it to
+    /// determine the length of the checksum. So for Bitcoin addresses, it is okay
+    /// to be sloppy and specify bech32 when bech32m is intended, or vice-versa.
+    /// (For [`Self::validate_checksum`], of course, you do need to use the correct
+    /// checksum algorithm for the string you're validating.)
+    pub fn data_iter<Ck: Checksum>(&self) -> Result<ParsedDataIter<Ck>, Error> {
+        self.checksum_length_checks::<Ck>()?;
+        Ok(ParsedDataIter {
+            iter: FeIter { iter: self.data_chk.iter().copied() }
+                .take(self.data_chk.len() - Ck::CHECKSUM_LENGTH)
+                .fes_to_bytes(),
+            ck: PhantomData,
+        })
+    }
+
+    /// Returns for the witness version.
+    pub fn witness_version(&self) -> Option<u8> { self.witness_version }
+
+    /// Returns the human-readable part (in lowercase without allocation).
+    pub fn hrp(&self) -> Hrp {
+        self.hrp
+    }
+}
+
+/// A character iterator over a parsed HRP string.
+#[allow(clippy::type_complexity)]
+pub struct ParsedDataIter<'s, Ck: Checksum> {
+    // We need `Copied` because non of our adaptor iterators use referenced items.
+    iter: FeToByteIter<iter::Take<FeIter<iter::Copied<slice::Iter<'s, u8>>>>>,
+    ck: PhantomData<Ck>,
+}
+
+impl<'s, Ck: Checksum> Iterator for ParsedDataIter<'s, Ck> {
+    type Item = u8;
+    fn next(&mut self) -> Option<u8> { self.iter.next() }
+    fn size_hint(&self) -> (usize, Option<usize>) { self.iter.size_hint() }
+}
+
+/// Helper iterator adaptor that maps an iterator of valid bech32 character ASCII bytes to an
+/// iterator of field elements.
+///
+/// This iterator is a performance optimization. Equivalent, but significantly faster than, using
+/// `hrp_string.data_chk.iter().copied().map(Fe32::from_char_unchecked)`.
+///
+/// # Panics
+///
+/// If any `u8` in the input iterator is out of range for an [`Fe32`]. Should only be used on data
+/// that has already been checked for validity (eg, by using `check_characters`).
+struct FeIter<I: Iterator<Item = u8>> {
+    iter: I,
+}
+
+impl<I> Iterator for FeIter<I>
+where
+    I: Iterator<Item = u8>,
+{
+    type Item = Fe32;
+    fn next(&mut self) -> Option<Fe32> { self.iter.next().map(Fe32::from_char_unchecked) }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        // Each ASCII character is an fe32 so iterators are the same size.
+        self.iter.size_hint()
+    }
+}
+
+/// Checks whether a given HRP string has data characters in the bech32 alphabet (incl. checksum
+/// characters), and that the whole string has consistent casing (hrp, data, and checksum).
+///
+/// # Returns
+///
+/// The byte-index into the string where the '1' separator occurs, or an error if it does not.
+fn check_characters(s: &str) -> Result<usize, Error> {
+    let mut has_upper = false;
+    let mut has_lower = false;
+    let mut req_bech32 = true;
+    let mut sep_pos = None;
+    for (n, ch) in s.char_indices().rev() {
+        if ch == SEP && sep_pos.is_none() {
+            req_bech32 = false;
+            sep_pos = Some(n);
+        }
+        if req_bech32 {
+            Fe32::from_char(ch).map_err(|_| Error::InvalidChar(ch))?;
+        }
+        if ch.is_ascii_uppercase() {
+            has_upper = true;
+        } else if ch.is_ascii_lowercase() {
+            has_lower = true;
+        }
+    }
+    if has_upper && has_lower {
+        Err(Error::MixedCase)
+    } else if let Some(pos) = sep_pos {
+        Ok(pos)
+    } else {
+        Err(Error::MissingSeparator)
+    }
+}
+
+/// Errors types for Bech32 (hrpstring) encoding / decoding.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Error {
+    /// Human-readable part is invalid.
+    InvalidHrp(hrp::Error),
+    /// String does not contain the separator character.
+    MissingSeparator,
+    /// The checksum does not match the rest of the data.
+    InvalidChecksum,
+    /// Attempt conversion of an invalid witness version string/number.
+    InvalidWitnessVersion(gf32::Error),
+    /// The data payload is empty.
+    InvalidDataEmpty,
+    /// The checksum is not a valid length.
+    InvalidChecksumLength,
+    /// Some part of the string contains an invalid character.
+    InvalidChar(char),
+    /// The bit conversion failed due to a padding issue.
+    InvalidPadding,
+    /// The whole string must be of one case.
+    MixedCase,
+}
+
+impl From<hrp::Error> for Error {
+    fn from(e: hrp::Error) -> Self { Error::InvalidHrp(e) }
+}
+
+impl From<Infallible> for Error {
+    fn from(v: Infallible) -> Self { match v {} }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use Error::*;
+
+        match *self {
+            InvalidHrp(ref e) => write_err!(f, "invalid human-readable part"; e),
+            MissingSeparator => write!(f, "missing human-readable separator, \"{}\"", SEP),
+            InvalidChecksum => write!(f, "invalid checksum"),
+            InvalidWitnessVersion(ref e) => write_err!(f, "witness version error"; e),
+            InvalidDataEmpty => write!(f, "invalid data - payload is empty"),
+            InvalidChecksumLength => write!(f, "the checksum is not a valid length"),
+            InvalidChar(n) => write!(f, "invalid character (code={})", n),
+            InvalidPadding => write!(f, "invalid padding"),
+            MixedCase => write!(f, "mixed-case strings not allowed"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use Error::*;
+
+        match *self {
+            InvalidHrp(ref e) => Some(e),
+            InvalidWitnessVersion(ref e) => Some(e),
+            MissingSeparator
+            | MixedCase
+            | InvalidChecksum
+            | InvalidDataEmpty
+            | InvalidChecksumLength
+            | InvalidChar(_)
+            | InvalidPadding => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[allow(unused_variables)] // Triggered by matches macro.
+    fn bip_173_invalid_hrpstring_parsing_fails() {
+        let invalid: Vec<(&str, Error)> = vec!(
+            ("\u{20}1nwldj5",
+             Error::InvalidChar('\u{20}')),
+            ("\u{7F}1axkwrx",
+             Error::InvalidChar('\u{7F}')),
+            ("\u{80}1eym55h",
+             Error::InvalidChar('\u{80}')),
+            ("an84characterslonghumanreadablepartthatcontainsthetheexcludedcharactersbioandnumber11d6pts4",
+             Error::InvalidHrp(hrp::Error::TooLong(84))),
+            ("pzry9x0s0muk",
+             Error::MissingSeparator),
+            ("1pzry9x0s0muk",
+             Error::InvalidHrp(hrp::Error::Empty)),
+            ("x1b4n0q5v",
+             Error::InvalidChar('b')),
+            ("de1lg7wt\u{ff}",
+             Error::InvalidChar('\u{ff}')),
+            ("10a06t8",
+             Error::InvalidHrp(hrp::Error::Empty)),
+            ("1qzzfhee",
+             Error::InvalidHrp(hrp::Error::Empty)),
+        );
+
+        for (s, expected_error) in invalid {
+            assert!(matches!(Parsed::new_with_witness_version(s), Err(expected_error)));
+            assert!(matches!(Parsed::new(s), Err(expected_error)));
+        }
+    }
+
+    #[test]
+    #[allow(unused_variables)] // Triggered by matches macro.
+    fn bip_173_invalid_hrpstring_because_of_invalid_checksum() {
+        let p = Parsed::new("li1dgmt3").expect("invalid checksum still parses");
+        assert!(matches!(p.validate_checksum::<crate::Bech32>(), Err(Error::InvalidChecksumLength)))
+    }
+
+    #[test]
+    #[allow(unused_variables)] // Triggered by matches macro.
+    fn bip_350_invalid_hrpstring_parsing_fails() {
+        let invalid: Vec<(&str, Error)> = vec!(
+            ("\u{20}1xj0phk",
+             Error::InvalidChar('\u{20}')),
+            ("\u{7F}1g6xzxy",
+             Error::InvalidChar('\u{7F}')),
+            ("\u{80}1g6xzxy",
+             Error::InvalidChar('\u{7F}')),
+            ("an84characterslonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1569pvx",
+             Error::InvalidHrp(hrp::Error::TooLong(84))),
+            ("qyrz8wqd2c9m",
+             Error::MissingSeparator),
+            ("1qyrz8wqd2c9m",
+             Error::InvalidHrp(hrp::Error::Empty)),
+            ("y1b0jsk6g",
+             Error::InvalidChar('b')),
+            ("lt1igcx5c0",
+             Error::InvalidChar('i')),
+            ("mm1crxm3i",
+             Error::InvalidChar('i')),
+            ("au1s5cgom",
+             Error::InvalidChar('o')),
+            ("16plkw9",
+             Error::InvalidHrp(hrp::Error::Empty)),
+            ("1p2gdwpf",
+             Error::InvalidHrp(hrp::Error::Empty)),
+
+        );
+
+        for (s, expected_error) in invalid {
+            assert!(matches!(Parsed::new_with_witness_version(s), Err(expected_error)));
+            assert!(matches!(Parsed::new(s), Err(expected_error)));
+        }
+    }
+
+    #[test]
+    #[allow(unused_variables)] // Triggered by matches macro.
+    fn bip_350_invalid_hrpstring_because_of_invalid_checksum() {
+        // Note the "bc1p2" test case is not from the bip test vectors.
+        let invalid: Vec<&str> = vec!["in1muywd", "bc1p2"];
+
+        for s in invalid {
+            let p = Parsed::new(s).expect("invalid checksum still parses");
+            assert!(matches!(
+                p.validate_checksum::<crate::Bech32m>(),
+                Err(Error::InvalidChecksumLength)
+            ))
+        }
+    }
+
+    #[test]
+    fn check_hrp_lowercase() {
+        let addr = "bc1zw508d6qejxtdg4y5r3zarvaryvg6kdaj";
+        let parsed = Parsed::new(addr).expect("failed to parse address");
+        assert_eq!(parsed.hrp(), Hrp::parse_unchecked("bc"));
+    }
+
+    #[test]
+    fn check_hrp_uppercase_returns_lower() {
+        let addr = "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4";
+        let parsed = Parsed::new(addr).expect("failed to parse address");
+        assert_eq!(parsed.hrp(), Hrp::parse_unchecked("bc"));
+    }
+
+    #[test]
+    fn check_hrp_max_length() {
+        let s = "an83characterlonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1569pvx";
+        let parsed = Parsed::new(s).expect("failed to parse address");
+        assert_eq!(
+            parsed.hrp(),
+            Hrp::parse_unchecked("an83characterlonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio")
+        );
+    }
+}

--- a/src/primitives/iter.rs
+++ b/src/primitives/iter.rs
@@ -1,0 +1,414 @@
+// SPDX-License-Identifier: MIT
+
+//! Iterator Adaptors
+//!
+//! This module provides iterator adaptors that can be used to verify and generate checksums, HRP
+//! strings, etc., in a variety of ways, without any allocations.
+//!
+//! In general, directly using these adaptors is not very ergonomic, and users are recommended to
+//! instead use the higher-level functions at the root of this crate.
+//!
+//! # Examples
+//!
+//! ```rust
+//! use bech32::primitives::iter::{ByteIterExt, Fe32IterExt};
+//! use bech32::primitives::gf32::Fe32;
+//! use bech32::primitives::hrp::Hrp;
+//! use bech32::primitives::Bech32;
+//!
+//! let witness_prog = [
+//!     0x75, 0x1e, 0x76, 0xe8, 0x19, 0x91, 0x96, 0xd4,
+//!     0x54, 0x94, 0x1c, 0x45, 0xd1, 0xb3, 0xa3, 0x23,
+//!     0xf1, 0x43, 0x3b, 0xd6,
+//! ];
+//! let hrp = Hrp::parse_unchecked("bc");
+//! let iterator = witness_prog
+//!     .iter()
+//!     .copied() // Iterate over bytes.
+//!     .bytes_to_fes() // Convert bytes to field elements in-line.
+//!     .with_witness_v0() // Pre-pend witness version.
+//!     .checksum::<Bech32>() // Convert to a [`ChecksumIter`] (append a bech32 checksum).
+//!     .with_checksummed_hrp(&hrp) // Feed HRP into the checksum.
+//!     .hrp_char(&hrp); // Turn the fe stream into a char stream with HRP.
+//! let hrpstring: String = iterator.collect();
+//! assert_eq!(hrpstring.to_uppercase(), "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4");
+//! ```
+
+use crate::primitives::checksum::{self, Checksum, PackedFe32};
+use crate::primitives::gf32::Fe32;
+use crate::primitives::hrp::{self, Hrp};
+
+/// Extension trait for byte iterators which provides an adaptor to GF32 elements
+pub trait ByteIterExt: Sized + Iterator<Item = u8> {
+    /// Obtain the GF32 iterator
+    fn bytes_to_fes(mut self) -> ByteToFeIter<Self> {
+        ByteToFeIter { last_byte: self.next(), bit_offset: 0, iter: self }
+    }
+}
+impl<I> ByteIterExt for I where I: Iterator<Item = u8> {}
+
+/// Iterator adaptor that converts bytes to GF32 elements. If the total number
+/// of bits is not a multiple of 5, it right-pads with 0 bits.
+#[derive(Clone, PartialEq, Eq)]
+pub struct ByteToFeIter<I: Iterator<Item = u8>> {
+    last_byte: Option<u8>,
+    bit_offset: usize,
+    iter: I,
+}
+
+impl<I> Iterator for ByteToFeIter<I>
+where
+    I: Iterator<Item = u8>,
+{
+    type Item = Fe32;
+    fn next(&mut self) -> Option<Fe32> {
+        use core::cmp::Ordering::*;
+
+        let bit_offset = {
+            let ret = self.bit_offset;
+            self.bit_offset = (self.bit_offset + 5) % 8;
+            ret
+        };
+
+        if let Some(last) = self.last_byte {
+            match bit_offset.cmp(&3) {
+                Less => Some(Fe32((last >> (3 - bit_offset)) & 0x1f)),
+                Equal => {
+                    self.last_byte = self.iter.next();
+                    Some(Fe32(last & 0x1f))
+                }
+                Greater => {
+                    self.last_byte = self.iter.next();
+                    let next = self.last_byte.unwrap_or(0);
+                    Some(Fe32(((last << (bit_offset - 3)) | (next >> (11 - bit_offset))) & 0x1f))
+                }
+            }
+        } else {
+            None
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (min, max) = self.iter.size_hint();
+        let (min, max) = match self.last_byte {
+            // +1 because we set last_byte with call to `next`.
+            Some(_) => (min + 1, max.map(|max| max + 1)),
+            None => (min, max),
+        };
+
+        let min = bytes_len_to_fes_len(min);
+        let max = max.map(bytes_len_to_fes_len);
+
+        (min, max)
+    }
+}
+
+/// The number of fes encoded by n bytes, rounded up because we pad the fes.
+fn bytes_len_to_fes_len(bytes: usize) -> usize {
+    let bits = bytes * 8;
+    (bits + 4) / 5
+}
+
+/// Extension trait for field element iterators
+pub trait Fe32IterExt: Sized + Iterator<Item = Fe32> {
+    /// Adapts the Fe32 iterator to output bytes instead.
+    ///
+    /// If the total number of bits is not a multiple of 8, any trailing bits
+    /// are simply dropped.
+    fn fes_to_bytes(mut self) -> FeToByteIter<Self> {
+        FeToByteIter { last_fe: self.next(), bit_offset: 0, iter: self }
+    }
+
+    /// Adapts the Fe32 iterator by prepending `Fe::32:Q` (witness version 0).
+    fn with_witness_v0(self) -> WitnessVersionIter<Self> { self.with_witness_version(Fe32::Q) }
+
+    /// Adapts the Fe32 iterator by prepending `Fe::32:P` (witness version 1).
+    fn with_witness_v1(self) -> WitnessVersionIter<Self> { self.with_witness_version(Fe32::P) }
+
+    /// Adapts the Fe32 iterator by prepending `fe` (witness version).
+    ///
+    /// Accepts any `Fe32`, does no checks on the validity of `witness_version`.
+    fn with_witness_version(self, witness_version: Fe32) -> WitnessVersionIter<Self> {
+        WitnessVersionIter { witness_version: Some(witness_version), iter: self }
+    }
+
+    /// Adapts the Fe32 iterator to append a checksum to the end of the data.
+    ///
+    /// Because the HRP of a bech32 string needs to be expanded before being
+    /// checksummed, this iterator is a little bit inconvenient to use on raw
+    /// data. The [`ChecksumIter::with_checksummed_hrp`] methods may be of use.
+    fn checksum<Ck: Checksum>(self) -> ChecksumIter<Self, Ck> {
+        ChecksumIter {
+            iter: self,
+            checksum_remaining: Ck::CHECKSUM_LENGTH,
+            checksum_engine: checksum::Engine::new(),
+        }
+    }
+
+    /// Adapts the Fe32 iterator to output characters using `hrp` for the human-readable part.
+    ///
+    /// Note, `hrp` is expected to be the same as that fed into the checksum engine with
+    /// `with_checksummed_hrp`.
+    fn hrp_char(self, hrp: &Hrp) -> HrpCharIter<'_, Self> {
+        HrpCharIter { hrp_iter: hrp.lowercase_char_iter(), fe_iter: self, hrp_done: false }
+    }
+}
+impl<I> Fe32IterExt for I where I: Iterator<Item = Fe32> {}
+
+/// Iterator adaptor that converts GF32 elements to bytes. If the total number
+/// of bits is not a multiple of 8, any trailing bits are dropped.
+///
+/// Note that if there are 5 or more trailing bits, the result will be that
+/// an entire field element is dropped. If this occurs, the input was an
+/// invalid length for a bech32 string, but this iterator does not do any
+/// checks for this.
+#[derive(Clone, PartialEq, Eq)]
+pub struct FeToByteIter<I: Iterator<Item = Fe32>> {
+    last_fe: Option<Fe32>,
+    bit_offset: usize,
+    iter: I,
+}
+
+impl<I> Iterator for FeToByteIter<I>
+where
+    I: Iterator<Item = Fe32>,
+{
+    type Item = u8;
+    fn next(&mut self) -> Option<u8> {
+        let bit_offset = {
+            let ret = self.bit_offset;
+            self.bit_offset = (self.bit_offset + 8) % 5;
+            ret
+        };
+
+        if let Some(last) = self.last_fe {
+            let mut ret = last.0 << (3 + bit_offset);
+
+            self.last_fe = self.iter.next();
+            let next1 = self.last_fe?;
+            if bit_offset > 2 {
+                self.last_fe = self.iter.next();
+                let next2 = self.last_fe?;
+                ret |= next1.0 << (bit_offset - 2);
+                ret |= next2.0 >> (7 - bit_offset);
+            } else {
+                ret |= next1.0 >> (2 - bit_offset);
+                if self.bit_offset == 0 {
+                    self.last_fe = self.iter.next();
+                }
+            }
+
+            Some(ret)
+        } else {
+            None
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        // If the total number of bits is not a multiple of 8, any trailing bits are dropped.
+        let fes_len_to_bytes_len = |n| n * 5 / 8;
+
+        let (fes_min, fes_max) = self.iter.size_hint();
+        let min = fes_len_to_bytes_len(fes_min);
+        let max = fes_max.map(|max| fes_len_to_bytes_len(max) + 1);
+        (min, max)
+    }
+}
+
+/// Iterator adaptor that just prepends a single character to a field element stream.
+///
+/// More ergonomic to use than `std::iter::once(fe).chain(iter)`.
+pub struct WitnessVersionIter<I>
+where
+    I: Iterator<Item = Fe32>,
+{
+    witness_version: Option<Fe32>,
+    iter: I,
+}
+
+impl<I> Iterator for WitnessVersionIter<I>
+where
+    I: Iterator<Item = Fe32>,
+{
+    type Item = Fe32;
+
+    fn next(&mut self) -> Option<Fe32> { self.witness_version.take().or_else(|| self.iter.next()) }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (min, max) = self.iter.size_hint();
+        match self.witness_version {
+            None => (min, max),
+            Some(_) => (min + 1, max.map(|max| max + 1)),
+        }
+    }
+}
+
+/// Iterator adaptor for field-element-yielding iterator, which tacks a
+/// checksum onto the end of the yielded data.
+#[derive(Clone, PartialEq, Eq)]
+pub struct ChecksumIter<I, Ck>
+where
+    I: Iterator<Item = Fe32>,
+    Ck: Checksum,
+{
+    iter: I,
+    checksum_remaining: usize,
+    checksum_engine: checksum::Engine<Ck>,
+}
+
+impl<I, Ck> ChecksumIter<I, Ck>
+where
+    I: Iterator<Item = Fe32>,
+    Ck: Checksum,
+{
+    /// Helper function to input an HRP into the underlying checksum engine of the iterator.
+    ///
+    /// This function is infallible, but if you feed it a non-ASCII `hrp` it probably will
+    /// cause your checksum engine to produce useless results.
+    ///
+    /// Also, if you call this function after the iterator has already yielded a value then
+    /// you will get useless results.
+    pub fn with_checksummed_hrp(mut self, hrp: &Hrp) -> Self {
+        self.checksum_engine.input_hrp(hrp);
+        self
+    }
+
+    /// Helper function to input an extra field element into the underling
+    /// checksum engine of the iterator.
+    pub fn with_checksummed_fe(mut self, fe: Fe32) -> Self {
+        self.checksum_engine.input_fe(fe);
+        self
+    }
+}
+
+impl<I, Ck> Iterator for ChecksumIter<I, Ck>
+where
+    I: Iterator<Item = Fe32>,
+    Ck: Checksum,
+{
+    type Item = Fe32;
+
+    fn next(&mut self) -> Option<Fe32> {
+        match self.iter.next() {
+            Some(fe) => {
+                self.checksum_engine.input_fe(fe);
+                Some(fe)
+            }
+            None =>
+                if self.checksum_remaining == 0 {
+                    None
+                } else {
+                    if self.checksum_remaining == Ck::CHECKSUM_LENGTH {
+                        self.checksum_engine.input_target_residue();
+                    }
+                    self.checksum_remaining -= 1;
+                    Some(Fe32(self.checksum_engine.residue().unpack(self.checksum_remaining)))
+                },
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (min, max) = self.iter.size_hint();
+        (min + self.checksum_remaining, max.map(|max| max + self.checksum_remaining))
+    }
+}
+
+/// Iterator adaptor which takes a stream of field elements, converts it to characters prefixed by
+/// an HRP. If `fe_iter` is a checksummed iter, it is expected that the `hrp` strings are identical.
+pub struct HrpCharIter<'hrp, I>
+where
+    I: Iterator<Item = Fe32>,
+{
+    hrp_iter: hrp::LowercaseCharIter<'hrp>,
+    fe_iter: I,
+    hrp_done: bool,
+}
+
+impl<'hrp, I> Iterator for HrpCharIter<'hrp, I>
+where
+    I: Iterator<Item = Fe32>,
+{
+    type Item = char;
+
+    fn next(&mut self) -> Option<char> {
+        if !self.hrp_done {
+            match self.hrp_iter.next() {
+                Some(c) => return Some(c),
+                None => {
+                    self.hrp_done = true;
+                    return Some('1');
+                }
+            }
+        }
+        self.fe_iter.next().map(Fe32::to_char)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (min, max) = self.fe_iter.size_hint();
+        let add = if !self.hrp_done {
+            self.hrp_iter.len() + 1 // hrp | SEP
+        } else {
+            0
+        };
+
+        (min + add, max.map(|max| max + add))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn iterator_adaptors() {
+        // This test is based on the test vector
+        // BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4: 0014751e76e8199196d454941c45d1b3a323f1433bd6
+        // from BIP-173.
+
+        // 1. Convert bytes to field elements, via iterator
+        #[rustfmt::skip]
+        let data = [
+            0x75, 0x1e, 0x76, 0xe8, 0x19, 0x91, 0x96, 0xd4,
+            0x54, 0x94, 0x1c, 0x45, 0xd1, 0xb3, 0xa3, 0x23,
+            0xf1, 0x43, 0x3b, 0xd6,
+        ];
+
+        assert!(data
+            .iter()
+            .copied()
+            .bytes_to_fes()
+            .map(Fe32::to_char)
+            .eq("w508d6qejxtdg4y5r3zarvary0c5xw7k".chars()));
+
+        // 2. Convert field elements to bytes, via iterator
+        let char_len = "w508d6qejxtdg4y5r3zarvary0c5xw7k".len();
+        assert_eq!(data.iter().copied().bytes_to_fes().size_hint(), (char_len, Some(char_len)));
+
+        let fe_iter = "w508d6qejxtdg4y5r3zarvary0c5xw7k"
+            .bytes()
+            .map(|b| Fe32::from_char(char::from(b)).unwrap());
+
+        assert!(fe_iter.clone().fes_to_bytes().eq(data.iter().copied()));
+
+        let iter = data.iter().copied().bytes_to_fes();
+        assert_eq!(iter.size_hint().0, char_len);
+
+        let checksummed_len = char_len + 6;
+        let iter = iter.checksum::<crate::primitives::Bech32>();
+        assert_eq!(iter.size_hint().0, checksummed_len);
+
+        let hrp = Hrp::parse_unchecked("bc");
+        // Does not add the hrp to the iterator, only adds it to the checksum engine.
+        let iter = iter.with_checksummed_hrp(&hrp);
+        assert_eq!(iter.size_hint().0, checksummed_len);
+
+        // Does not add the separator to the iterator, only adds it to the checksum engine.
+        let iter = iter.with_checksummed_fe(Fe32::Q);
+        assert_eq!(iter.size_hint().0, checksummed_len);
+
+        let iter = iter.map(Fe32::to_char);
+        assert_eq!(iter.size_hint().0, checksummed_len);
+
+        assert!(iter.eq("w508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4".chars()));
+    }
+}

--- a/src/primitives/mod.rs
+++ b/src/primitives/mod.rs
@@ -5,6 +5,7 @@
 pub mod checksum;
 pub mod gf32;
 pub mod hrp;
+pub mod hrpstring;
 pub mod iter;
 
 use checksum::{Checksum, PackedNull};

--- a/src/primitives/mod.rs
+++ b/src/primitives/mod.rs
@@ -5,6 +5,7 @@
 pub mod checksum;
 pub mod gf32;
 pub mod hrp;
+pub mod iter;
 
 use checksum::{Checksum, PackedNull};
 


### PR DESCRIPTION
Throwing this up for you to look at @apoelstra when/if you get time.

Draft because the current implementation fails to parse a valid bech32 address from mainnet but AFAICT the code correctly implements [BIP-173](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki) - where is the bug?

Failing test is at the bottom of `hrpstring.rs`
```rust
    #[test]
    fn exclude_strings_that_are_not_valid_bech32_length_0() {
        // This is a real mainnet address so it must be valid.
        // https://blockstream.info/address/bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq
        let addr = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq";
        let parsed = Parsed::new(addr).expect("failed to parse address");

        assert_eq!(Ok(()), parsed.validate_checksum::<crate::Bech32>())
    }
```

It fails with `InvalidDataLength` from the call to `checksum_length_checks`:
```rust
    /// Helper function that sanity checks the length of an HRP string for a given checksum algorithm.
    ///
    /// Specifically, check that
    ///     * the data is at least long enough to contain a checksum
    ///     * that the length doesn't imply any "useless characters" where no bits are used
    fn checksum_length_checks<Ck: Checksum>(&self) -> Result<(), Error> {
        let len = match self.witness_version {
            Some(_) => self.data_chk.len() + 1,
            None => self.data_chk.len(),
        };

        if len < Ck::CHECKSUM_LENGTH {
            return Err(Error::InvalidChecksumLength);
        }
        // From BIP-173:
        // > Re-arrange those bits into groups of 8 bits. Any incomplete group at the
        // > end MUST be 4 bits or less, MUST be all zeroes, and is discarded.
        if (len - Ck::CHECKSUM_LENGTH) * 5 % 8 > 4 {
            return Err(Error::InvalidDataLength);
        }

        Ok(())
    }
```
And the relevant part of the bip is in bold:

Decoding

Software interpreting a segwit address:

- MUST verify that the human-readable part is "bc" for mainnet and "tb" for testnet.
- MUST verify that the first decoded data value (the witness version) is between 0 and 16, inclusive.
- Convert the rest of the data to bytes:
   - Translate the values to 5 bits, most significant bit first.
   - **Re-arrange those bits into groups of 8 bits. Any incomplete group at the end MUST be 4 bits or less, MUST be all zeroes, and is discarded.**
   - There MUST be between 2 and 40 groups, which are interpreted as the bytes of the witness program.
