### PR TITLE
Add `iter` and `hrpstring`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,5 @@ default = ["std"]
 std = ["alloc"]
 alloc = []
 
-[dependencies.arrayvec]
-version = "0.7.1"
-default-features = false
-optional = true
-
 [target.'cfg(mutate)'.dev-dependencies]
 mutagen = { git = "https://github.com/llogiq/mutagen" }

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Bitcoin-specific address encoding is handled by the `bitcoin-bech32` crate.
 
 ## MSRV
 
-This library should always compile with any combination of features excluding "arrayvec" on **Rust 1.48.0**.
+This library should always compile with any combination of features on **Rust 1.48.0**.
 
 
 ## Githooks

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,2 @@
 msrv = "1.48.0"
+type-complexity-threshold = 1000

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -40,20 +40,13 @@ if [ "${DO_FMT-false}" = true ]; then
     cargo fmt --check
 fi
 
-if [ "${DO_FEATURE_MATRIX-false}" = true ]; then
-    # No features
-    build_and_test ""
+# Defaults / sanity checks
+cargo build                     # This enables std and alloc
+cargo test
 
-    # Feature combos
-    build_and_test "std"
-    build_and_test "alloc"
-    build_and_test "std alloc"
-    # arrayvec breaks the MSRV
-    if [ $MSRV = false ]; then
-        build_and_test "arrayvec"
-        build_and_test "std arrayvec"
-        build_and_test "alloc arrayvec"
-    fi
+if [ "${DO_FEATURE_MATRIX-false}" = true ]; then
+    build_and_test ""           # No features
+    build_and_test "alloc"      # Just alloc
 fi
 
 # Build the docs if told to (this only works with the nightly toolchain)

--- a/embedded/no-allocator/Cargo.toml
+++ b/embedded/no-allocator/Cargo.toml
@@ -11,7 +11,7 @@ cortex-m-rt = "0.6.10"
 cortex-m-semihosting = "0.3.3"
 panic-halt = "0.2.0"
 arrayvec = { version = "0.7.1", default-features = false }
-bech32 = { path = "../../", default-features = false, features = ["arrayvec"] }
+bech32 = { path = "../../", default-features = false }
 
 [[bin]]
 name = "no-allocator"

--- a/embedded/no-allocator/src/main.rs
+++ b/embedded/no-allocator/src/main.rs
@@ -7,12 +7,11 @@
 #![no_main]
 #![no_std]
 
-use panic_halt as _;
-
 use arrayvec::{ArrayString, ArrayVec};
-use bech32::{self, u5, ComboError, FromBase32, ToBase32, Variant, Hrp};
+use bech32::{self, u5, ComboError, FromBase32, Hrp, ToBase32, Variant};
 use cortex_m_rt::entry;
 use cortex_m_semihosting::{debug, hprintln};
+use panic_halt as _;
 
 // Note: `#[global_allocator]` is NOT set.
 
@@ -26,9 +25,7 @@ fn main() -> ! {
 
     let hrp = Hrp::parse("bech32").unwrap();
 
-    bech32::encode_to_fmt_anycase(&mut encoded, hrp, &base32, Variant::Bech32)
-        .unwrap()
-        .unwrap();
+    bech32::encode_to_fmt_anycase(&mut encoded, hrp, &base32, Variant::Bech32).unwrap().unwrap();
     test(&*encoded == "bech321qqqsyrhqy2a");
 
     hprintln!("{}", encoded).unwrap();

--- a/embedded/no-allocator/src/main.rs
+++ b/embedded/no-allocator/src/main.rs
@@ -1,14 +1,13 @@
-//! Test `no_std` build of `bech32`.
+//! Test `no_std` build of `bech32` without an allocator.
 //!
-//! Build with: `cargo rustc -- -C link-arg=-nostartfiles`.
-//!
+//! Build with: `cargo +nightly rustc -- -C link-arg=-nostartfiles`.
 
 #![feature(alloc_error_handler)]
 #![no_main]
 #![no_std]
 
 use arrayvec::{ArrayString, ArrayVec};
-use bech32::{self, u5, ComboError, FromBase32, Hrp, ToBase32, Variant};
+use bech32::{u5, ByteIterExt, Hrp, Variant};
 use cortex_m_rt::entry;
 use cortex_m_semihosting::{debug, hprintln};
 use panic_halt as _;
@@ -17,29 +16,23 @@ use panic_halt as _;
 
 #[entry]
 fn main() -> ! {
-    let mut encoded = ArrayString::<30>::new();
-
-    let mut base32 = ArrayVec::<u5, 30>::new();
-
-    [0x00u8, 0x01, 0x02].write_base32(&mut base32).unwrap();
-
     let hrp = Hrp::parse("bech32").unwrap();
+    let data_iter = [0x00u8, 0x01, 0x02].iter().copied().bytes_to_fes();
 
-    bech32::encode_to_fmt_anycase(&mut encoded, hrp, &base32, Variant::Bech32).unwrap().unwrap();
+    let data = data_iter.collect::<ArrayVec<u5, 30>>();
+    let mut encoded = ArrayString::<30>::new();
+    bech32::encode_to_fmt(&mut encoded, hrp, data, Variant::Bech32).unwrap();
+
     test(&*encoded == "bech321qqqsyrhqy2a");
 
     hprintln!("{}", encoded).unwrap();
 
-    let mut decoded = ArrayVec::<u5, 30>::new();
+    let (parsed, variant) = bech32::decode(&encoded).expect("failed to decode");
 
-    let mut scratch = ArrayVec::<u5, 30>::new();
-
-    let (got_hrp, data, variant) =
-        bech32::decode_lowercase::<ComboError, _, _>(&encoded, &mut decoded, &mut scratch).unwrap();
-    test(got_hrp == hrp);
-    let res = ArrayVec::<u8, 30>::from_base32(&data).unwrap();
-    test(&res == [0x00, 0x01, 0x02].as_ref());
     test(variant == Variant::Bech32);
+    test(parsed.hrp() == hrp);
+    let data = parsed.byte_iter().collect::<ArrayVec<u8, 30>>();
+    test(&data == [0x00, 0x01, 0x02].as_ref());
 
     debug::exit(debug::EXIT_SUCCESS);
 

--- a/embedded/with-allocator/src/main.rs
+++ b/embedded/with-allocator/src/main.rs
@@ -3,18 +3,18 @@
 #![no_std]
 
 extern crate alloc;
+use core::alloc::Layout;
+
+use alloc_cortex_m::CortexMHeap;
+use bech32::{self, FromBase32, Hrp, ToBase32, Variant};
+use cortex_m::asm;
+use cortex_m_rt::entry;
+use cortex_m_semihosting::{debug, hprintln};
 use panic_halt as _;
 
 use self::alloc::string::ToString;
 use self::alloc::vec;
 use self::alloc::vec::Vec;
-use core::alloc::Layout;
-
-use alloc_cortex_m::CortexMHeap;
-use bech32::{self, FromBase32, ToBase32, Variant, Hrp};
-use cortex_m::asm;
-use cortex_m_rt::entry;
-use cortex_m_semihosting::{debug, hprintln};
 
 #[global_allocator]
 static ALLOCATOR: CortexMHeap = CortexMHeap::empty();
@@ -27,12 +27,7 @@ fn main() -> ! {
     unsafe { ALLOCATOR.init(cortex_m_rt::heap_start() as usize, HEAP_SIZE) }
 
     let hrp = Hrp::parse("bech32").unwrap();
-    let encoded = bech32::encode(
-        hrp,
-        vec![0x00, 0x01, 0x02].to_base32(),
-        Variant::Bech32,
-    )
-    .unwrap();
+    let encoded = bech32::encode(hrp, vec![0x00, 0x01, 0x02].to_base32(), Variant::Bech32).unwrap();
     test(encoded == "bech321qqqsyrhqy2a".to_string());
 
     hprintln!("{}", encoded).unwrap();

--- a/fuzz/fuzz_targets/decode_rnd.rs
+++ b/fuzz/fuzz_targets/decode_rnd.rs
@@ -1,14 +1,19 @@
 extern crate bech32;
 
+use bech32::Fe32;
+
 fn do_test(data: &[u8]) {
     let data_str = String::from_utf8_lossy(data);
     let decoded = bech32::decode(&data_str);
-    let b32 = match decoded {
-        Ok(b32) => b32,
+    let (parsed, variant) = match decoded {
+        Ok((parsed, variant)) => (parsed, variant),
         Err(_) => return,
     };
 
-    assert_eq!(bech32::encode(b32.0, b32.1, b32.2).unwrap(), data_str);
+    let hrp = parsed.hrp();
+    let data = parsed.fe32_iter().collect::<Vec<Fe32>>();
+
+    assert_eq!(bech32::encode(hrp, data, variant).expect("failed to encode"), data_str);
 }
 
 #[cfg(feature = "afl")]

--- a/fuzz/fuzz_targets/encode_decode.rs
+++ b/fuzz/fuzz_targets/encode_decode.rs
@@ -3,7 +3,7 @@ extern crate bech32;
 use std::convert::TryFrom;
 use std::str;
 
-use bech32::Hrp;
+use bech32::{Fe32, Hrp};
 
 fn do_test(data: &[u8]) {
     if data.len() < 1 {
@@ -33,12 +33,13 @@ fn do_test(data: &[u8]) {
             match Hrp::parse(&s) {
                 Err(_) => return,
                 Ok(hrp) => {
-                    if let Ok(data_str) = bech32::encode(hrp, &dp, variant).map(|b32| b32.to_string()) {
-                        let decoded = bech32::decode(&data_str);
-                        let b32 = decoded.expect("should be able to decode own encoding");
+                    let encoded = bech32::encode(hrp, &dp, variant).expect("failed to encode");
+                    let (parsed, variant) = bech32::decode(&encoded).expect("failed to decode");
 
-                        assert_eq!(bech32::encode(b32.0, &b32.1, b32.2).unwrap(), data_str);
-                    }
+                    let hrp = parsed.hrp();
+                    let data = parsed.fe32_iter().collect::<Vec<Fe32>>();
+
+                    assert_eq!(bech32::encode(hrp, data, variant).expect("failed to encode"), encoded);
                 }
             }
         }

--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -47,3 +47,6 @@ git diff-index --check --cached $against -- || exit 1
 
 # Check that code lints cleanly.
 cargo clippy --all-features -- -D warnings || exit 1
+
+# Check that there are no formatting issues.
+cargo +nightly fmt --check || exit 1

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,6 @@
 // Written by the Rust Bitcoin developers.
 // SPDX-License-Identifier: CC0-1.0
 
-// TODO: We can get this from `bitcoin-internals` crate once that is released.
-
 //! # Error
 //!
 //! Error handling macros and helpers.

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,10 +1,4 @@
-// Written by the Rust Bitcoin developers.
 // SPDX-License-Identifier: CC0-1.0
-
-//! # Error
-//!
-//! Error handling macros and helpers.
-//!
 
 /// Formats error.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -434,9 +434,8 @@ pub fn encode_to_fmt_anycase<T: AsRef<[u5]>>(
 ///
 /// This method is intended for implementing traits from [`std::fmt`].
 ///
-/// # Errors
+/// # Deviations from standard.
 ///
-/// * Deviations from standard.
 /// * No length limits are enforced for the data part.
 pub fn encode_without_checksum_to_fmt<T: AsRef<[u5]>>(
     fmt: &mut dyn fmt::Write,
@@ -484,9 +483,8 @@ impl Variant {
 
 /// Encodes a bech32 payload to string.
 ///
-/// # Errors
+/// # Deviations from standard.
 ///
-/// * Deviations from standard.
 /// * No length limits are enforced for the data part.
 #[cfg(feature = "alloc")]
 pub fn encode<T: AsRef<[u5]>>(hrp: Hrp, data: T, variant: Variant) -> Result<String, Error> {
@@ -497,9 +495,8 @@ pub fn encode<T: AsRef<[u5]>>(hrp: Hrp, data: T, variant: Variant) -> Result<Str
 
 /// Encodes a bech32 payload to string without the checksum.
 ///
-/// # Errors
+/// # Deviations from standard.
 ///
-/// * Deviations from standard.
 /// * No length limits are enforced for the data part.
 #[cfg(feature = "alloc")]
 pub fn encode_without_checksum<T: AsRef<[u5]>>(hrp: Hrp, data: T) -> Result<String, Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,24 +11,6 @@
 //!
 //! The original description in [BIP-0173](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki)
 //! has more details. See also [BIP-0350](https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki).
-//!
-#![cfg_attr(
-    feature = "std",
-    doc = "
-# Examples
-```
-use bech32::{self, FromBase32, ToBase32, Variant, Hrp};
-let hrp = Hrp::parse(\"bech32\").expect(\"bech32 is valid\");
-let encoded = bech32::encode(hrp, vec![0x00, 0x01, 0x02].to_base32(), Variant::Bech32).unwrap();
-assert_eq!(encoded, \"bech321qqqsyrhqy2a\".to_string());
-let (hrp, data, variant) = bech32::decode(&encoded).unwrap();
-assert_eq!(hrp.to_string(), \"bech32\");
-assert_eq!(Vec::<u8>::from_base32(&data).unwrap(), vec![0x00, 0x01, 0x02]);
-assert_eq!(variant, Variant::Bech32);
-```
-"
-)]
-//!
 
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
 // Experimental features we need.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,404 +30,46 @@ extern crate core;
 
 #[cfg(all(feature = "alloc", not(feature = "std"), not(test)))]
 use alloc::{string::String, vec::Vec};
-use core::convert::{Infallible, TryFrom};
-use core::{fmt, mem};
+use core::fmt;
 
-pub use crate::primitives::checksum::Checksum;
-use crate::primitives::checksum::{self, PackedFe32};
-use crate::primitives::hrp;
+// Re-export all types from `primitives` modules that appear in the public API.
+pub use crate::primitives::gf32::Fe32;
 pub use crate::primitives::hrp::Hrp;
-pub use crate::primitives::{Bech32, Bech32m};
+pub use crate::primitives::hrpstring::Parsed;
+// Also re-export the iter extensions because the conversion methods are core functionality.
+pub use crate::primitives::iter::{ByteIterExt, Fe32IterExt};
+pub use crate::primitives::{Bech32, Bech32m, NoChecksum};
 
 mod error;
 pub mod primitives;
 
-#[cfg(feature = "arrayvec")]
-use arrayvec::{ArrayVec, CapacityError};
 pub use primitives::gf32::Fe32 as u5;
-
-/// Interface to write `u5`s into a sink.
-pub trait WriteBase32 {
-    /// Write error.
-    type Error: fmt::Debug;
-
-    /// Writes a `u5` slice to `self`.
-    fn write(&mut self, data: &[u5]) -> Result<(), Self::Error> {
-        for b in data {
-            self.write_u5(*b)?;
-        }
-        Ok(())
-    }
-
-    /// Writes a single `u5`.
-    fn write_u5(&mut self, data: u5) -> Result<(), Self::Error> { self.write(&[data]) }
-}
-
-/// Interface to write `u8`s into a sink
-///
-/// Like `std::io::Writer`, but because the associated type is no_std compatible.
-pub trait WriteBase256 {
-    /// Write error.
-    type Error: fmt::Debug;
-
-    /// Writes a `u8` slice.
-    fn write(&mut self, data: &[u8]) -> Result<(), Self::Error> {
-        for b in data {
-            self.write_u8(*b)?;
-        }
-        Ok(())
-    }
-
-    /// Writes a single `u8`.
-    fn write_u8(&mut self, data: u8) -> Result<(), Self::Error> { self.write(&[data]) }
-}
-
-const CHECKSUM_LENGTH: usize = 6;
-
-/// Allocationless Bech32 writer that accumulates the checksum data internally and writes them out
-/// in the end.
-pub struct Bech32Writer<'a, Ck: Checksum> {
-    formatter: &'a mut dyn fmt::Write,
-    engine: checksum::Engine<Ck>,
-}
-
-impl<'a, Ck: Checksum> Bech32Writer<'a, Ck> {
-    /// Creates a new writer that can write a bech32 string without allocating itself.
-    ///
-    /// This is a rather low-level API and doesn't check the HRP or data length for standard
-    /// compliance.
-    fn new(hrp: Hrp, fmt: &'a mut dyn fmt::Write) -> Result<Bech32Writer<'a, Ck>, fmt::Error> {
-        let mut engine = checksum::Engine::new();
-        engine.input_hrp(&hrp);
-
-        for c in hrp.lowercase_char_iter() {
-            fmt.write_char(c)?;
-        }
-        fmt.write_char(SEP)?;
-
-        Ok(Bech32Writer { formatter: fmt, engine })
-    }
-
-    /// Writes out the checksum at the end.
-    ///
-    /// If this method isn't explicitly called this will happen on drop.
-    pub fn finalize(mut self) -> fmt::Result {
-        self.write_checksum()?;
-        mem::forget(self);
-        Ok(())
-    }
-
-    /// Calculates and writes a checksum to `self`.
-    fn write_checksum(&mut self) -> fmt::Result {
-        self.engine.input_target_residue();
-
-        let mut checksum_remaining = self::CHECKSUM_LENGTH;
-        while checksum_remaining > 0 {
-            checksum_remaining -= 1;
-
-            let fe = u5::try_from(self.engine.residue().unpack(checksum_remaining))
-                .expect("unpack returns valid field element");
-            self.formatter.write_char(fe.to_char())?;
-        }
-
-        Ok(())
-    }
-}
-
-impl<'a, Ck: Checksum> WriteBase32 for Bech32Writer<'a, Ck> {
-    type Error = fmt::Error;
-
-    fn write_u5(&mut self, data: u5) -> fmt::Result {
-        self.engine.input_fe(data);
-        self.formatter.write_char(data.to_char())
-    }
-}
-
-impl<'a, Ck: Checksum> Drop for Bech32Writer<'a, Ck> {
-    fn drop(&mut self) {
-        self.write_checksum().expect("Unhandled error writing the checksum on drop.")
-    }
-}
-
-/// Parses/converts base32 slice to `Self`.
-///
-/// This trait is the reciprocal of `ToBase32`.
-pub trait FromBase32: Sized {
-    /// The associated error which can be returned from parsing (e.g. because of bad padding).
-    type Error;
-
-    /// Converts a base32 slice to `Self`.
-    fn from_base32(b32: &[u5]) -> Result<Self, Self::Error>;
-}
-
-macro_rules! write_base_n {
-    { $tr:ident, $ty:ident, $meth:ident } => {
-        #[cfg(feature = "arrayvec")]
-        impl<const L: usize> $tr for ArrayVec<$ty, L> {
-            type Error = CapacityError;
-
-            fn write(&mut self, data: &[$ty]) -> Result<(), Self::Error> {
-                self.try_extend_from_slice(data)?;
-                Ok(())
-            }
-
-            fn $meth(&mut self, data: $ty) -> Result<(), Self::Error> {
-                self.push(data);
-                Ok(())
-            }
-        }
-
-        #[cfg(feature = "alloc")]
-        impl $tr for Vec<$ty> {
-            type Error = Infallible;
-
-            fn write(&mut self, data: &[$ty]) -> Result<(), Self::Error> {
-                self.extend_from_slice(data);
-                Ok(())
-            }
-
-            fn $meth(&mut self, data: $ty) -> Result<(), Self::Error> {
-                self.push(data);
-                Ok(())
-            }
-        }
-    }
-}
-
-write_base_n! { WriteBase32, u5, write_u5 }
-write_base_n! { WriteBase256, u8, write_u8 }
-
-#[cfg(feature = "arrayvec")]
-#[derive(Clone, Debug, PartialEq, Eq)]
-/// Combination of Errors for use with array vec
-pub enum ComboError {
-    /// Error from this crate
-    Bech32Error(Error),
-    /// Error from `arrayvec`.
-    WriteError(CapacityError),
-}
-#[cfg(feature = "arrayvec")]
-impl From<Error> for ComboError {
-    fn from(e: Error) -> ComboError { ComboError::Bech32Error(e) }
-}
-#[cfg(feature = "arrayvec")]
-impl From<CapacityError> for ComboError {
-    fn from(e: CapacityError) -> ComboError { ComboError::WriteError(e) }
-}
-#[cfg(feature = "arrayvec")]
-impl From<hrp::Error> for ComboError {
-    fn from(e: hrp::Error) -> ComboError { ComboError::Bech32Error(Error::Hrp(e)) }
-}
-
-#[cfg(feature = "arrayvec")]
-impl<const L: usize> FromBase32 for ArrayVec<u8, L> {
-    type Error = ComboError;
-
-    /// Convert base32 to base256, removes null-padding if present, returns
-    /// `Err(Error::InvalidPadding)` if padding bits are unequal `0`
-    fn from_base32(b32: &[u5]) -> Result<Self, Self::Error> {
-        let mut ret: ArrayVec<u8, L> = ArrayVec::new();
-        convert_bits_in::<ComboError, _, _>(b32, 5, 8, false, &mut ret)?;
-        Ok(ret)
-    }
-}
-
-#[cfg(feature = "alloc")]
-impl FromBase32 for Vec<u8> {
-    type Error = Error;
-
-    /// Converts base32 (slice of u5s) to base256 (vector of u8s).
-    ///
-    /// Removes null-padding if present.
-    ///
-    /// # Errors
-    ///
-    /// Uses [`convert_bits`] to convert 5 bit values to 8 bit values, see that function for errors.
-    fn from_base32(b32: &[u5]) -> Result<Self, Self::Error> { convert_bits(b32, 5, 8, false) }
-}
-
-/// A trait for converting a value to a type `T` that represents a `u5` slice.
-///
-/// This trait is the reciprocal of `FromBase32`.
-pub trait ToBase32 {
-    /// Converts `Self` to a base32 vector.
-    #[cfg(feature = "alloc")]
-    fn to_base32(&self) -> Vec<u5> {
-        let mut vec = Vec::new();
-        self.write_base32(&mut vec).unwrap();
-        vec
-    }
-
-    /// Encodes `Self` as base32 and writes it to the supplied writer.
-    ///
-    /// Implementations should not allocate.
-    fn write_base32<W: WriteBase32>(&self, writer: &mut W)
-        -> Result<(), <W as WriteBase32>::Error>;
-}
-
-/// Interface to calculate the length of the base32 representation before actually serializing.
-pub trait Base32Len: ToBase32 {
-    /// Calculates the base32 serialized length.
-    fn base32_len(&self) -> usize;
-}
-
-impl<T: AsRef<[u8]> + ?Sized> ToBase32 for T {
-    fn write_base32<W: WriteBase32>(
-        &self,
-        writer: &mut W,
-    ) -> Result<(), <W as WriteBase32>::Error> {
-        // Amount of bits left over from last round, stored in buffer.
-        let mut buffer_bits = 0u32;
-        // Holds all unwritten bits left over from last round. The bits are stored beginning from
-        // the most significant bit. E.g. if buffer_bits=3, then the byte with bits a, b and c will
-        // look as follows: [a, b, c, 0, 0, 0, 0, 0]
-        let mut buffer: u8 = 0;
-
-        for &b in self.as_ref() {
-            // Write first u5 if we have to write two u5s this round. That only happens if the
-            // buffer holds too many bits, so we don't have to combine buffer bits with new bits
-            // from this rounds byte.
-            if buffer_bits >= 5 {
-                writer.write_u5(u5((buffer & 0b1111_1000) >> 3))?;
-                buffer <<= 5;
-                buffer_bits -= 5;
-            }
-
-            // Combine all bits from buffer with enough bits from this rounds byte so that they fill
-            // a u5. Save reamining bits from byte to buffer.
-            let from_buffer = buffer >> 3;
-            let from_byte = b >> (3 + buffer_bits); // buffer_bits <= 4
-
-            writer.write_u5(u5(from_buffer | from_byte))?;
-            buffer = b << (5 - buffer_bits);
-            buffer_bits += 3;
-        }
-
-        // There can be at most two u5s left in the buffer after processing all bytes, write them.
-        if buffer_bits >= 5 {
-            writer.write_u5(u5((buffer & 0b1111_1000) >> 3))?;
-            buffer <<= 5;
-            buffer_bits -= 5;
-        }
-
-        if buffer_bits != 0 {
-            writer.write_u5(u5(buffer >> 3))?;
-        }
-
-        Ok(())
-    }
-}
-
-impl<T: AsRef<[u8]> + ?Sized> Base32Len for T {
-    fn base32_len(&self) -> usize {
-        let bits = self.as_ref().len() * 8;
-        if bits % 5 == 0 {
-            bits / 5
-        } else {
-            bits / 5 + 1
-        }
-    }
-}
-
-/// A trait to convert between u8 arrays and u5 arrays without changing the content of the elements,
-/// but checking that they are in range.
-pub trait CheckBase32<T> {
-    /// Error type if conversion fails
-    type Error;
-
-    /// Checks if all values are in range and return slice-like-type of `u5` values.
-    fn check_base32(self) -> Result<T, Self::Error>;
-}
-
-impl<T, U: AsRef<[u8]>> CheckBase32<T> for U
-where
-    T: AsRef<[u5]>,
-    T: core::iter::FromIterator<u5>,
-{
-    type Error = Error;
-
-    fn check_base32(self) -> Result<T, Self::Error> {
-        self.as_ref()
-            .iter()
-            .map(|x| u5::try_from(*x).map_err(Error::TryFrom))
-            .collect::<Result<T, Error>>()
-    }
-}
-
-impl<U: AsRef<[u8]>> CheckBase32<()> for U {
-    type Error = Error;
-
-    fn check_base32(self) -> Result<(), Error> {
-        self.as_ref()
-            .iter()
-            .map(|x| u5::try_from(*x).map(|_| ()).map_err(Error::TryFrom))
-            .find(|r| r.is_err())
-            .unwrap_or(Ok(()))
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum Case {
-    Upper,
-    Lower,
-    None,
-}
 
 /// Encodes a bech32 payload to a writer ([`fmt::Write`]) using lowercase.
 ///
 /// This method is intended for implementing traits from [`std::fmt`].
 ///
-/// # Errors
+/// # Deviations from standard.
 ///
-/// * Deviations from standard.
 /// * No length limits are enforced for the data part.
 pub fn encode_to_fmt<T: AsRef<[u5]>>(
     fmt: &mut dyn fmt::Write,
     hrp: Hrp,
     data: T,
     variant: Variant,
-) -> Result<fmt::Result, Error> {
-    let mut hrp = hrp;
-    hrp.lowercase();
-    encode_to_fmt_anycase(fmt, hrp, data, variant)
-}
-
-/// Encode a bech32 payload to an [fmt::Write], but with any case.
-/// This method is intended for implementing traits from [core::fmt] without [std].
-///
-/// See `encode_to_fmt` for meaning of errors.
-pub fn encode_to_fmt_anycase<T: AsRef<[u5]>>(
-    fmt: &mut dyn fmt::Write,
-    hrp: Hrp,
-    data: T,
-    variant: Variant,
-) -> Result<fmt::Result, Error> {
+) -> fmt::Result {
+    let iter = data.as_ref().iter().copied();
     match variant {
-        Variant::Bech32 => {
-            let res = Bech32Writer::<Bech32>::new(hrp, fmt);
-            match res {
-                Ok(mut writer) => {
-                    Ok(writer.write(data.as_ref()).and_then(|_| {
-                        // Finalize manually to avoid panic on drop if write fails
-                        writer.finalize()
-                    }))
-                }
-                Err(e) => Ok(Err(e)),
-            }
-        }
-        Variant::Bech32m => {
-            let res = Bech32Writer::<Bech32m>::new(hrp, fmt);
-            match res {
-                Ok(mut writer) => {
-                    Ok(writer.write(data.as_ref()).and_then(|_| {
-                        // Finalize manually to avoid panic on drop if write fails
-                        writer.finalize()
-                    }))
-                }
-                Err(e) => Ok(Err(e)),
-            }
-        }
+        Variant::Bech32 =>
+            for c in iter.checksummed::<Bech32>().hrp_checksummed(&hrp).hrpstring_chars() {
+                fmt.write_char(c)?;
+            },
+        Variant::Bech32m =>
+            for c in iter.checksummed::<Bech32m>().hrp_checksummed(&hrp).hrpstring_chars() {
+                fmt.write_char(c)?;
+            },
     }
+    Ok(())
 }
 
 /// Encodes a bech32 payload without a checksum to a writer ([`fmt::Write`]).
@@ -467,29 +109,15 @@ pub enum Variant {
     Bech32m,
 }
 
-const BECH32_CONST: u32 = 1;
-const BECH32M_CONST: u32 = 0x2bc8_30a3;
-
-impl Variant {
-    /// Produces the variant based on the remainder of the polymod operation.
-    fn from_remainder(c: u32) -> Option<Self> {
-        match c {
-            BECH32_CONST => Some(Variant::Bech32),
-            BECH32M_CONST => Some(Variant::Bech32m),
-            _ => None,
-        }
-    }
-}
-
 /// Encodes a bech32 payload to string.
 ///
 /// # Deviations from standard.
 ///
 /// * No length limits are enforced for the data part.
 #[cfg(feature = "alloc")]
-pub fn encode<T: AsRef<[u5]>>(hrp: Hrp, data: T, variant: Variant) -> Result<String, Error> {
+pub fn encode<T: AsRef<[u5]>>(hrp: Hrp, data: T, variant: Variant) -> Result<String, fmt::Error> {
     let mut buf = String::new();
-    encode_to_fmt(&mut buf, hrp, data, variant)?.unwrap();
+    crate::encode_to_fmt(&mut buf, hrp, data, variant)?;
     Ok(buf)
 }
 
@@ -505,209 +133,43 @@ pub fn encode_without_checksum<T: AsRef<[u5]>>(hrp: Hrp, data: T) -> Result<Stri
     Ok(buf)
 }
 
-/// Decodes a bech32 string into the raw HRP and the data bytes.
-///
-/// # Returns
-///
-/// The human-readable part in lowercase, the data with the checksum removed, and the encoding.
-#[cfg(feature = "alloc")]
-pub fn decode(s: &str) -> Result<(Hrp, Vec<u5>, Variant), Error> {
-    let (hrp_lower, mut data) = split_and_decode(s)?;
-    if data.len() < CHECKSUM_LENGTH {
-        return Err(Error::InvalidLength);
+/// Decodes a bech32 string.
+pub fn decode(s: &str) -> Result<(Parsed, Variant), Error> {
+    if let Ok(p) = Parsed::new::<Bech32m>(s) {
+        return Ok((p, Variant::Bech32m));
     }
-
-    // Ensure checksum
-    match verify_checksum(hrp_lower, &data) {
-        Some(variant) => {
-            // Remove checksum from data payload
-            data.truncate(data.len() - CHECKSUM_LENGTH);
-
-            Ok((hrp_lower, data, variant))
-        }
-        None => Err(Error::InvalidChecksum),
+    match Parsed::new::<Bech32>(s) {
+        Ok(p) => Ok((p, Variant::Bech32)),
+        Err(e) => Err(Error::Hrpstring(e)),
     }
 }
 
-/// Decodes a bech32 string into the raw HRP and the data bytes, assuming no checksum.
-///
-/// # Returns
-///
-/// The human-readable part in lowercase and the data.
-#[cfg(feature = "alloc")]
-pub fn decode_without_checksum(s: &str) -> Result<(Hrp, Vec<u5>), Error> { split_and_decode(s) }
-
-/// Decodes a bech32 string into the raw HRP and the `u5` data.
-#[cfg(feature = "alloc")]
-fn split_and_decode(s: &str) -> Result<(Hrp, Vec<u5>), Error> {
-    // Split at separator and check for two pieces
-    let (raw_hrp, raw_data) = match s.rfind(SEP) {
-        None => return Err(Error::MissingSeparator),
-        Some(sep) => {
-            let (hrp, data) = s.split_at(sep);
-            (hrp, &data[1..])
-        }
-    };
-
-    let (hrp, mut case) = Hrp::parse_and_case(raw_hrp)?;
-
-    // Check data payload
-    let data = raw_data
-        .chars()
-        .map(|c| {
-            if c.is_lowercase() {
-                match case {
-                    Case::Upper => return Err(Error::MixedCase),
-                    Case::None => case = Case::Lower,
-                    Case::Lower => {}
-                }
-            } else if c.is_uppercase() {
-                match case {
-                    Case::Lower => return Err(Error::MixedCase),
-                    Case::None => case = Case::Upper,
-                    Case::Upper => {}
-                }
-            }
-            u5::from_char(c).map_err(Error::TryFrom)
-        })
-        .collect::<Result<Vec<u5>, Error>>()?;
-
-    Ok((hrp, data))
-}
-
-// TODO deduplicate some
-/// Decode a lowercase bech32 string into the raw HRP and the data bytes.
-///
-/// Less flexible than [decode], but don't allocate.
-pub fn decode_lowercase<'b, E, R, S>(
-    s: &str,
-    data: &'b mut R,
-    scratch: &mut S,
-) -> Result<(Hrp, &'b [u5], Variant), E>
-where
-    R: WriteBase32 + AsRef<[u5]>,
-    S: WriteBase32 + AsRef<[u5]>,
-    E: From<R::Error>,
-    E: From<S::Error>,
-    E: From<Error>,
-    E: core::convert::From<primitives::hrp::Error>,
-{
-    // Ensure overall length is within bounds
-    if s.len() < 8 {
-        Err(Error::InvalidLength)?;
-    }
-
-    // Split at separator and check for two pieces
-    let (raw_hrp, raw_data) = match s.rfind(SEP) {
-        None => Err(Error::MissingSeparator)?,
-        Some(sep) => {
-            let (hrp, data) = s.split_at(sep);
-            (hrp, &data[1..])
-        }
-    };
-    if raw_data.len() < 6 {
-        Err(Error::InvalidLength)?;
-    }
-
-    let (hrp, case) = Hrp::parse_and_case(raw_hrp)?;
-
-    // Check data payload
-    for c in raw_data.chars() {
-        match case {
-            Case::Upper => Err(Error::MixedCase)?,
-            Case::None | Case::Lower => {}
-        }
-        data.write_u5(u5::from_char(c).map_err(Error::TryFrom)?)?;
-    }
-
-    // Ensure checksum
-    let variant =
-        verify_checksum_in(hrp, data.as_ref(), scratch)?.ok_or(Error::MissingSeparator)?;
-
-    let dbl: usize = data.as_ref().len();
-    Ok((hrp, &(*data).as_ref()[..dbl.saturating_sub(6)], variant))
-}
-
-#[cfg(feature = "alloc")]
-fn verify_checksum(hrp: Hrp, data: &[u5]) -> Option<Variant> {
-    let mut v: Vec<u5> = Vec::new();
-    match verify_checksum_in(hrp, data, &mut v) {
-        Ok(v) => v,
-        Err(e) => match e {},
-    }
-}
-
-fn verify_checksum_in<T>(hrp: Hrp, data: &[u5], v: &mut T) -> Result<Option<Variant>, T::Error>
-where
-    T: WriteBase32 + AsRef<[u5]>,
-{
-    hrp_expand_in(hrp, v)?;
-    v.write(data)?;
-    Ok(Variant::from_remainder(polymod(v.as_ref())))
-}
-
-fn hrp_expand_in<T: WriteBase32>(hrp: Hrp, v: &mut T) -> Result<(), T::Error> {
-    for b in hrp.lowercase_byte_iter() {
-        v.write_u5(u5::try_from(b >> 5).expect("can't be out of range, max. 7"))?;
-    }
-    v.write_u5(u5::try_from(0).unwrap())?;
-    for b in hrp.lowercase_byte_iter() {
-        v.write_u5(u5::try_from(b & 0x1f).expect("can't be out of range, max. 31"))?;
-    }
-    Ok(())
-}
-
-fn polymod(values: &[u5]) -> u32 {
-    let mut chk: u32 = 1;
-    let mut b: u8;
-    for v in values {
-        b = (chk >> 25) as u8;
-        chk = (chk & 0x01ff_ffff) << 5 ^ (u32::from(*v.as_ref()));
-
-        for (i, item) in GEN.iter().enumerate() {
-            if (b >> i) & 1 == 1 {
-                chk ^= item;
-            }
-        }
-    }
-    chk
+/// Decodes a bech32 string, assuming no checksum.
+pub fn decode_without_checksum(s: &str) -> Result<Parsed, Error> {
+    let p = Parsed::new::<NoChecksum>(s)?;
+    Ok(p)
 }
 
 /// Human-readable part and data part separator.
 const SEP: char = '1';
 
-/// Generator coefficients
-const GEN: [u32; 5] = [0x3b6a_57b2, 0x2650_8e6d, 0x1ea1_19fa, 0x3d42_33dd, 0x2a14_62b3];
-
 /// Error types for Bech32 encoding / decoding.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Error {
-    /// String does not contain the separator character.
-    MissingSeparator,
-    /// The checksum does not match the rest of the data.
-    InvalidChecksum,
-    /// The data or human-readable part is too long or too short.
-    InvalidLength,
-    /// Some part of the string contains an invalid character.
-    InvalidChar(char),
-    /// The bit conversion failed due to a padding issue.
-    InvalidPadding,
-    /// The whole string must be of one case.
-    MixedCase,
-    /// Attempted to convert a value which overflows a `u5`.
-    Overflow,
     /// Conversion to u5 failed.
     TryFrom(primitives::gf32::Error),
     /// HRP parsing failed.
-    Hrp(hrp::Error),
+    Hrp(primitives::hrp::Error),
+    /// hrpstring parsing failed.
+    Hrpstring(primitives::hrpstring::Error),
 }
 
-impl From<Infallible> for Error {
-    fn from(v: Infallible) -> Self { match v {} }
+impl From<primitives::hrp::Error> for Error {
+    fn from(e: primitives::hrp::Error) -> Self { Error::Hrp(e) }
 }
 
-impl From<hrp::Error> for Error {
-    fn from(e: hrp::Error) -> Self { Error::Hrp(e) }
+impl From<primitives::hrpstring::Error> for Error {
+    fn from(e: primitives::hrpstring::Error) -> Self { Error::Hrpstring(e) }
 }
 
 impl fmt::Display for Error {
@@ -715,15 +177,9 @@ impl fmt::Display for Error {
         use Error::*;
 
         match *self {
-            MissingSeparator => write!(f, "missing human-readable separator, \"{}\"", SEP),
-            InvalidChecksum => write!(f, "invalid checksum"),
-            InvalidLength => write!(f, "invalid length"),
-            InvalidChar(n) => write!(f, "invalid character (code={})", n),
-            InvalidPadding => write!(f, "invalid padding"),
-            MixedCase => write!(f, "mixed-case strings not allowed"),
             TryFrom(ref e) => write_err!(f, "conversion to u5 failed"; e),
-            Overflow => write!(f, "attempted to convert a value which overflows a u5"),
             Hrp(ref e) => write_err!(f, "HRP conversion failed"; e),
+            Hrpstring(ref e) => write_err!(f, "hrpstring conversion failed"; e),
         }
     }
 }
@@ -736,8 +192,7 @@ impl std::error::Error for Error {
         match *self {
             TryFrom(ref e) => Some(e),
             Hrp(ref e) => Some(e),
-            MissingSeparator | InvalidChecksum | InvalidLength | InvalidChar(_)
-            | InvalidPadding | MixedCase | Overflow => None,
+            Hrpstring(ref e) => Some(e),
         }
     }
 }
@@ -746,156 +201,12 @@ impl From<primitives::gf32::Error> for Error {
     fn from(e: primitives::gf32::Error) -> Self { Error::TryFrom(e) }
 }
 
-/// Error return when `TryFrom<T>` fails for T -> u5 conversion.
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
-pub enum TryFromIntError {
-    /// Attempted to convert a negative value to a `u5`.
-    NegOverflow,
-    /// Attempted to convert a value which overflows a `u5`.
-    PosOverflow,
-}
-
-impl fmt::Display for TryFromIntError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use TryFromIntError::*;
-
-        match *self {
-            NegOverflow => write!(f, "attempted to convert a negative value to a u5"),
-            PosOverflow => write!(f, "attempted to convert a value which overflows a u5"),
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for TryFromIntError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        use TryFromIntError::*;
-
-        match *self {
-            NegOverflow | PosOverflow => None,
-        }
-    }
-}
-
-// impl From<convert::Error> for Error {
-//     fn from(e: convert::Error) -> Self {
-//         Error::InvalidData(e)
-//     }
-// }
-
-/// Converts between bit sizes.
-///
-/// # Errors
-///
-/// * `Error::InvalidData` if any element of `data` is out of range.
-/// * `Error::InvalidPadding` if `pad == false` and the padding bits are not `0`.
-///
-/// # Panics
-///
-/// Function will panic if attempting to convert `from` or `to` a bit size that
-/// is 0 or larger than 8 bits i.e., `from` and `to` must within range `1..=8`.
-///
-/// # Examples
-///
-/// ```rust
-/// use bech32::convert_bits;
-/// let base5 = convert_bits(&[0xff], 8, 5, true);
-/// assert_eq!(base5.unwrap(), vec![0x1f, 0x1c]);
-/// ```
-#[cfg(feature = "alloc")]
-pub fn convert_bits<T>(data: &[T], from: u32, to: u32, pad: bool) -> Result<Vec<u8>, Error>
-where
-    T: Into<u8> + Copy,
-{
-    let mut ret: Vec<u8> = Vec::new();
-    convert_bits_in::<Error, _, _>(data, from, to, pad, &mut ret)?;
-    Ok(ret)
-}
-
-/// Convert between bit sizes without allocating
-///
-/// Like [convert_bits].
-pub fn convert_bits_in<E, T, R>(
-    data: &[T],
-    from: u32,
-    to: u32,
-    pad: bool,
-    ret: &mut R,
-) -> Result<(), E>
-where
-    T: Into<u8> + Copy,
-    R: WriteBase256,
-    E: From<Error>,
-    E: From<R::Error>,
-{
-    if from > 8 || to > 8 || from == 0 || to == 0 {
-        panic!("convert_bits `from` and `to` parameters 0 or greater than 8");
-    }
-    let mut acc: u32 = 0;
-    let mut bits: u32 = 0;
-    let maxv: u32 = (1 << to) - 1;
-    for value in data {
-        let v: u32 = u32::from(Into::<u8>::into(*value));
-        if (v >> from) != 0 {
-            // Input value exceeds `from` bit size
-            Err(Error::Overflow)?;
-        }
-        acc = (acc << from) | v;
-        bits += from;
-        while bits >= to {
-            bits -= to;
-            ret.write_u8(((acc >> bits) & maxv) as u8)?;
-        }
-    }
-    if pad {
-        if bits > 0 {
-            ret.write_u8(((acc << (to - bits)) & maxv) as u8)?;
-        }
-    } else if bits >= from || ((acc << (to - bits)) & maxv) != 0 {
-        Err(Error::InvalidPadding)?;
-    }
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "arrayvec")]
-    use arrayvec::ArrayString;
-
     use super::*;
 
     #[cfg(feature = "alloc")]
     fn hrp(s: &str) -> Hrp { Hrp::parse_unchecked(s) }
-
-    trait TextExt {
-        fn check_base32_vec(self) -> Result<Vec<u5>, Error>;
-    }
-    impl<U: AsRef<[u8]>> TextExt for U {
-        fn check_base32_vec(self) -> Result<Vec<u5>, Error> { self.check_base32() }
-    }
-
-    #[test]
-    #[cfg(feature = "alloc")]
-    fn getters_in() {
-        let mut data_scratch = Vec::new();
-        let mut scratch = Vec::new();
-        let decoded =
-            decode_lowercase::<Error, _, _>("bc1sw50qa3jx3s", &mut data_scratch, &mut scratch)
-                .unwrap();
-        let data = [16, 14, 20, 15, 0].check_base32_vec().unwrap();
-        assert_eq!(decoded.0.to_string(), "bc");
-        assert_eq!(decoded.1, data.as_slice());
-    }
-
-    #[test]
-    #[cfg(feature = "alloc")]
-    fn getters() {
-        let decoded = decode("BC1SW50QA3JX3S").unwrap();
-        let data = [16, 14, 20, 15, 0].check_base32_vec().unwrap();
-        assert_eq!(decoded.0, hrp("bc"));
-        assert_eq!(decoded.0.to_string(), "BC");
-        assert_eq!(decoded.1, data.as_slice());
-    }
 
     #[test]
     #[cfg(feature = "alloc")]
@@ -918,8 +229,11 @@ mod tests {
         );
         for s in strings {
             match decode(s) {
-                Ok((hrp, payload, variant)) => {
-                    let encoded = encode(hrp, payload, variant).unwrap();
+                Ok((parsed, variant)) => {
+                    let hrp = parsed.hrp();
+                    let data = parsed.fe32_iter().collect::<Vec<u5>>();
+                    let encoded =
+                        encode(hrp, data, variant).expect("failed to encode decoded parts");
                     assert_eq!(s.to_lowercase(), encoded.to_lowercase());
                 }
                 Err(e) => panic!("Did not decode: {:?} Reason: {:?}", s, e),
@@ -930,53 +244,55 @@ mod tests {
     #[test]
     #[cfg(feature = "alloc")]
     fn invalid_strings() {
+        use crate::primitives::{hrp, hrpstring};
+
         let pairs: Vec<(&str, Error)> = vec!(
             (" 1nwldj5",
-                Error::Hrp(hrp::Error::InvalidAsciiByte(b' '))),
+                Error::Hrpstring(hrpstring::Error::InvalidHrp(hrp::Error::InvalidAsciiByte(b' ')))),
             ("abc1\u{2192}axkwrx",
-                Error::TryFrom(primitives::gf32::Error::InvalidChar('\u{2192}'))),
+                Error::Hrpstring(hrpstring::Error::InvalidChar('\u{2192}'))),
             ("an84characterslonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1569pvx",
-                Error::Hrp(hrp::Error::TooLong(84))),
+                Error::Hrpstring(hrpstring::Error::InvalidHrp(hrp::Error::TooLong(84)))),
             ("pzry9x0s0muk",
-                Error::MissingSeparator),
+                Error::Hrpstring(hrpstring::Error::MissingSeparator)),
             ("1pzry9x0s0muk",
-                Error::Hrp(hrp::Error::Empty)),
+                Error::Hrpstring(hrpstring::Error::InvalidHrp(hrp::Error::Empty))),
             ("x1b4n0q5v",
-                Error::TryFrom(primitives::gf32::Error::InvalidChar('b'))),
+                Error::Hrpstring(hrpstring::Error::InvalidChar('b'))),
             ("ABC1DEFGOH",
-                Error::TryFrom(primitives::gf32::Error::InvalidChar('O'))),
+                Error::Hrpstring(hrpstring::Error::InvalidChar('O'))),
             ("li1dgmt3",
-                Error::InvalidLength),
+                Error::Hrpstring(hrpstring::Error::InvalidChecksumLength)),
             ("de1lg7wt\u{ff}",
-                Error::TryFrom(primitives::gf32::Error::InvalidChar('\u{ff}'))),
+                Error::Hrpstring(hrpstring::Error::InvalidChar('\u{ff}'))),
             ("\u{20}1xj0phk",
-                Error::Hrp(hrp::Error::InvalidAsciiByte(b' '))), // u20 is space character
+                Error::Hrpstring(hrpstring::Error::InvalidHrp(hrp::Error::InvalidAsciiByte(b' ')))), // u20 is space character
             ("\u{7F}1g6xzxy",
-                Error::Hrp(hrp::Error::InvalidAsciiByte(0x7f))),
+                Error::Hrpstring(hrpstring::Error::InvalidHrp(hrp::Error::InvalidAsciiByte(0x7f)))),
             ("an84characterslonghumanreadablepartthatcontainsthetheexcludedcharactersbioandnumber11d6pts4",
-                Error::Hrp(hrp::Error::TooLong(84))),
+                Error::Hrpstring(hrpstring::Error::InvalidHrp(hrp::Error::TooLong(84)))),
             ("qyrz8wqd2c9m",
-                Error::MissingSeparator),
+                Error::Hrpstring(hrpstring::Error::MissingSeparator)),
             ("1qyrz8wqd2c9m",
-                Error::Hrp(hrp::Error::Empty)),
+                Error::Hrpstring(hrpstring::Error::InvalidHrp(hrp::Error::Empty))),
             ("y1b0jsk6g",
-                Error::TryFrom(primitives::gf32::Error::InvalidChar('b'))),
+                Error::Hrpstring(hrpstring::Error::InvalidChar('b'))),
             ("lt1igcx5c0",
-                Error::TryFrom(primitives::gf32::Error::InvalidChar('i'))),
+                Error::Hrpstring(hrpstring::Error::InvalidChar('i'))),
             ("in1muywd",
-                Error::InvalidLength),
+                Error::Hrpstring(hrpstring::Error::InvalidChecksumLength)),
             ("mm1crxm3i",
-                Error::TryFrom(primitives::gf32::Error::InvalidChar('i'))),
+                Error::Hrpstring(hrpstring::Error::InvalidChar('i'))),
             ("au1s5cgom",
-                Error::TryFrom(primitives::gf32::Error::InvalidChar('o'))),
+                Error::Hrpstring(hrpstring::Error::InvalidChar('o'))),
             ("M1VUXWEZ",
-                Error::InvalidChecksum),
+                Error::Hrpstring(hrpstring::Error::InvalidChecksum)),
             ("16plkw9",
-                Error::Hrp(hrp::Error::Empty)),
+                Error::Hrpstring(hrpstring::Error::InvalidHrp(hrp::Error::Empty))),
             ("1p2gdwpf",
-                Error::Hrp(hrp::Error::Empty)),
+                Error::Hrpstring(hrpstring::Error::InvalidHrp(hrp::Error::Empty))),
             ("bc1p2",
-                Error::InvalidLength),
+                Error::Hrpstring(hrpstring::Error::InvalidChecksumLength)),
         );
         for p in pairs {
             let (s, expected_error) = p;
@@ -988,158 +304,22 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::type_complexity)]
-    #[cfg(feature = "alloc")]
-    fn valid_conversion() {
-        // Set of [data, from_bits, to_bits, pad, result]
-        let tests: Vec<(Vec<u8>, u32, u32, bool, Vec<u8>)> = vec![
-            (vec![0x01], 1, 1, true, vec![0x01]),
-            (vec![0x01, 0x01], 1, 1, true, vec![0x01, 0x01]),
-            (vec![0x01], 8, 8, true, vec![0x01]),
-            (vec![0x01], 8, 4, true, vec![0x00, 0x01]),
-            (vec![0x01], 8, 2, true, vec![0x00, 0x00, 0x00, 0x01]),
-            (vec![0x01], 8, 1, true, vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01]),
-            (vec![0xff], 8, 5, true, vec![0x1f, 0x1c]),
-            (vec![0x1f, 0x1c], 5, 8, false, vec![0xff]),
-        ];
-        for t in tests {
-            let (data, from_bits, to_bits, pad, expected_result) = t;
-            let result = convert_bits(&data, from_bits, to_bits, pad);
-            assert!(result.is_ok());
-            assert_eq!(result.unwrap(), expected_result);
-        }
-    }
-
-    #[test]
-    #[cfg(feature = "alloc")]
-    fn invalid_conversion() {
-        // Set of [data, from_bits, to_bits, pad, expected error]
-        let tests: Vec<(Vec<u8>, u32, u32, bool, Error)> = vec![
-            (vec![0xff], 8, 5, false, Error::InvalidPadding),
-            (vec![0x02], 1, 1, true, Error::Overflow),
-        ];
-        for t in tests {
-            let (data, from_bits, to_bits, pad, expected_error) = t;
-            let result = convert_bits(&data, from_bits, to_bits, pad);
-            assert!(result.is_err());
-            assert_eq!(result.unwrap_err(), expected_error);
-        }
-    }
-
-    #[test]
-    #[cfg(feature = "alloc")]
-    fn convert_bits_invalid_bit_size() {
-        use std::panic::{catch_unwind, set_hook, take_hook};
-
-        let invalid = &[(0, 8), (5, 0), (9, 5), (8, 10), (0, 16)];
-
-        for &(from, to) in invalid {
-            set_hook(Box::new(|_| {}));
-            let result = catch_unwind(|| {
-                let _ = convert_bits(&[0], from, to, true);
-            });
-            let _ = take_hook();
-            assert!(result.is_err());
-        }
-    }
-
-    #[test]
-    fn check_base32() {
-        assert!([0u8, 1, 2, 30, 31].check_base32_vec().is_ok());
-        assert!([0u8, 1, 2, 30, 31, 32].check_base32_vec().is_err());
-        assert!([0u8, 1, 2, 30, 31, 255].check_base32_vec().is_err());
-
-        assert!([1u8, 2, 3, 4].check_base32_vec().is_ok());
-        assert!(matches!(
-            [30u8, 31, 35, 20].check_base32_vec(),
-            Err(Error::TryFrom(primitives::gf32::Error::InvalidByte(35)))
-        ));
-    }
-
-    #[test]
     #[cfg(feature = "alloc")]
     fn test_encode() {
-        assert_eq!(Hrp::parse(""), Err(hrp::Error::Empty));
-    }
-
-    #[test]
-    #[cfg(feature = "alloc")]
-    fn from_base32() {
-        assert_eq!(Vec::from_base32(&[0x1f, 0x1c].check_base32_vec().unwrap()), Ok(vec![0xff]));
-        assert_eq!(
-            Vec::from_base32(&[0x1f, 0x1f].check_base32_vec().unwrap()),
-            Err(Error::InvalidPadding)
-        );
-    }
-
-    #[test]
-    #[cfg(feature = "alloc")]
-    fn to_base32() {
-        assert_eq!([0xffu8].to_base32(), [0x1f, 0x1c].check_base32_vec().unwrap());
-    }
-
-    #[test]
-    #[cfg(feature = "alloc")]
-    fn write_with_checksum() {
-        let hrp = hrp("lnbc");
-        let data = "Hello World!".as_bytes().to_base32();
-
-        let mut written_str = String::new();
-        {
-            let mut writer = Bech32Writer::<Bech32>::new(hrp, &mut written_str).unwrap();
-            writer.write(&data).unwrap();
-            writer.finalize().unwrap();
-        }
-
-        let encoded_str = encode(hrp, data, Variant::Bech32).unwrap();
-
-        assert_eq!(encoded_str, written_str);
-    }
-
-    #[test]
-    #[cfg(feature = "alloc")]
-    fn write_without_checksum() {
-        let hrp = hrp("lnbc");
-        let data = "Hello World!".as_bytes().to_base32();
-
-        let mut written_str = String::new();
-        {
-            let mut writer = Bech32Writer::<Bech32>::new(hrp, &mut written_str).unwrap();
-            writer.write(&data).unwrap();
-        }
-
-        let encoded_str = encode_without_checksum(hrp, data).unwrap();
-
-        assert_eq!(encoded_str, written_str[..written_str.len() - CHECKSUM_LENGTH]);
-    }
-
-    #[test]
-    #[cfg(feature = "alloc")]
-    fn write_with_checksum_on_drop() {
-        let hrp = hrp("lntb");
-        let data = "Hello World!".as_bytes().to_base32();
-
-        let mut written_str = String::new();
-        {
-            let mut writer = Bech32Writer::<Bech32>::new(hrp, &mut written_str).unwrap();
-            writer.write(&data).unwrap();
-        }
-
-        let encoded_str = encode(hrp, data, Variant::Bech32).unwrap();
-
-        assert_eq!(encoded_str, written_str);
+        assert_eq!(Hrp::parse(""), Err(primitives::hrp::Error::Empty));
     }
 
     #[test]
     #[cfg(feature = "alloc")]
     fn roundtrip_without_checksum() {
         let hrp = hrp("lnbc");
-        let data = "Hello World!".as_bytes().to_base32();
+        let data = "Hello World!".bytes().bytes_to_fes().collect::<Vec<u5>>();
 
         let encoded = encode_without_checksum(hrp, data.clone()).expect("failed to encode");
-        let (decoded_hrp, decoded_data) =
-            decode_without_checksum(&encoded).expect("failed to decode");
+        let parsed = decode_without_checksum(&encoded).expect("failed to decode");
 
+        let decoded_hrp = parsed.hrp();
+        let decoded_data = parsed.byte_iter().bytes_to_fes().collect::<Vec<u5>>();
         assert_eq!(decoded_hrp, hrp);
         assert_eq!(decoded_data, data);
     }
@@ -1147,54 +327,19 @@ mod tests {
     #[test]
     #[cfg(feature = "alloc")]
     fn test_hrp_case() {
+        let fes = [0x00, 0x00].iter().copied().bytes_to_fes().collect::<Vec<u5>>();
         // Tests for issue with HRP case checking being ignored for encoding
-        let encoded_str = encode(hrp("HRP"), [0x00, 0x00].to_base32(), Variant::Bech32).unwrap();
+        let encoded_str = encode(hrp("HRP"), fes, Variant::Bech32).expect("failed to encode");
 
         assert_eq!(encoded_str, "hrp1qqqq40atq3");
-    }
-
-    #[test]
-    fn try_from_err() {
-        assert!(u5::try_from(32_u8).is_err());
-        assert!(u5::try_from(32_u16).is_err());
-        assert!(u5::try_from(32_u32).is_err());
-        assert!(u5::try_from(32_u64).is_err());
-        assert!(u5::try_from(32_u128).is_err());
-    }
-
-    #[test]
-    #[cfg(feature = "arrayvec")]
-    fn test_arrayvec() {
-        let mut encoded = ArrayString::<30>::new();
-
-        let mut base32 = ArrayVec::<u5, 30>::new();
-
-        [0x00u8, 0x01, 0x02].write_base32(&mut base32).unwrap();
-
-        let bech32_hrp = Hrp::parse("bech32").expect("bech32 is valid");
-        encode_to_fmt_anycase(&mut encoded, bech32_hrp, &base32, Variant::Bech32).unwrap().unwrap();
-        assert_eq!(&*encoded, "bech321qqqsyrhqy2a");
-
-        println!("{}", encoded);
-
-        let mut decoded = ArrayVec::<u5, 30>::new();
-
-        let mut scratch = ArrayVec::<u5, 30>::new();
-
-        let (hrp, data, variant) =
-            decode_lowercase::<ComboError, _, _>(&encoded, &mut decoded, &mut scratch).unwrap();
-        assert_eq!(hrp.to_string(), "bech32");
-        let res = ArrayVec::<u8, 30>::from_base32(data).unwrap();
-        assert_eq!(&res, [0x00, 0x01, 0x02].as_ref());
-        assert_eq!(variant, Variant::Bech32);
     }
 
     #[test]
     #[cfg(feature = "alloc")]
     fn decode_bitcoin_bech32_address() {
         let addr = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq";
-        let (hrp, _data, variant) = crate::decode(addr).expect("address is well formed");
-        assert_eq!(hrp.to_string(), "bc");
+        let (parsed, variant) = crate::decode(addr).expect("address is well formed");
+        assert_eq!(parsed.hrp().to_string(), "bc");
         assert_eq!(variant, Variant::Bech32)
     }
 
@@ -1202,8 +347,8 @@ mod tests {
     #[cfg(feature = "alloc")]
     fn decode_bitcoin_bech32m_address() {
         let addr = "bc1p5d7rjq7g6rdk2yhzks9smlaqtedr4dekq08ge8ztwac72sfr9rusxg3297";
-        let (hrp, _data, variant) = crate::decode(addr).expect("address is well formed");
-        assert_eq!(hrp.to_string(), "bc");
+        let (parsed, variant) = crate::decode(addr).expect("address is well formed");
+        assert_eq!(parsed.hrp().to_string(), "bc");
         assert_eq!(variant, Variant::Bech32m)
     }
 
@@ -1211,37 +356,47 @@ mod tests {
     #[cfg(feature = "alloc")]
     fn decode_all_digit_hrp_uppercase_data() {
         let addr = "23451QAR0SRRR7XFKVY5L643LYDNW9RE59GTZZLKULZK";
-        let (hrp, data, variant) = crate::decode(addr).expect("address is well formed");
-        assert_eq!(hrp, Hrp::parse("2345").unwrap());
-        let hrp = Hrp::parse("2345").unwrap();
-        let s = crate::encode(hrp, data, variant).expect("failed to encode");
-        assert_eq!(s.to_uppercase(), addr);
+        let (parsed, variant) = crate::decode(addr).expect("address is well formed");
+
+        let got_hrp = parsed.hrp();
+        let want_hrp = Hrp::parse("2345").unwrap();
+        assert_eq!(got_hrp, want_hrp);
+
+        let data = parsed.fe32_iter().collect::<Vec<u5>>();
+        let encoded = encode(got_hrp, data, variant).expect("failed to encode decoded parts");
+        assert_eq!(encoded.to_uppercase(), addr);
     }
 
     #[test]
     #[cfg(feature = "alloc")]
-    fn writer_lowercases_hrp_when_adding_to_checksum() {
-        let addr = "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4";
-        let (_hrp, data, _variant) = crate::decode(addr).expect("failed to decode");
-        let data: Vec<u8> = FromBase32::from_base32(&data[1..]).expect("failed to convert u5s");
+    fn roundtrip_bitcoin_bech32_address() {
+        let addr = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq";
+        let (parsed, variant) = crate::decode(addr).expect("address is well formed");
 
-        let mut writer = String::new();
-        let mut bech32_writer = Bech32Writer::<Bech32>::new(Hrp::parse("BC").unwrap(), &mut writer)
-            .expect("failed to write hrp");
-        let version = u5::try_from(0).unwrap();
+        let hrp = parsed.hrp();
+        let data = parsed.fe32_iter().collect::<Vec<u5>>();
+        let encoded = crate::encode(hrp, data, variant).expect("failed to encode");
+        assert_eq!(encoded, addr);
+    }
 
-        WriteBase32::write_u5(&mut bech32_writer, version).expect("failed to write version");
-        ToBase32::write_base32(&data, &mut bech32_writer).expect("failed to write data");
+    #[test]
+    #[cfg(feature = "alloc")]
+    fn roundtrip_bitcoin_bech32m_address() {
+        let addr = "bc1p5d7rjq7g6rdk2yhzks9smlaqtedr4dekq08ge8ztwac72sfr9rusxg3297";
+        let (parsed, variant) = crate::decode(addr).expect("address is well formed");
 
-        drop(bech32_writer);
-
-        assert_eq!(writer, addr.to_lowercase());
+        let hrp = parsed.hrp();
+        let data = parsed.fe32_iter().collect::<Vec<u5>>();
+        let encoded = crate::encode(hrp, data, variant).expect("failed to encode");
+        assert_eq!(encoded, addr);
     }
 }
 
 #[cfg(bench)]
 mod benches {
     use test::{black_box, Bencher};
+
+    use super::*;
 
     #[bench]
     fn bech32_parse_address(bh: &mut Bencher) {
@@ -1267,10 +422,13 @@ mod benches {
     #[bench]
     fn encode_bech32_address(bh: &mut Bencher) {
         let addr = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq";
-        let (hrp, data, variant) = crate::decode(&addr).expect("address is well formed");
+        let (parsed, variant) = crate::decode(&addr).expect("address is well formed");
+
+        let hrp = parsed.hrp();
+        let data = parsed.fe32_iter().collect::<Vec<u5>>();
 
         bh.iter(|| {
-            let s = crate::encode(hrp, &data, variant).expect("failed to encode");
+            let s = crate::encode(hrp, &data, variant);
             black_box(&s);
         });
     }
@@ -1279,8 +437,11 @@ mod benches {
     #[bench]
     fn encode_to_fmt_bech32_address(bh: &mut Bencher) {
         let addr = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq";
-        let (hrp, data, variant) = crate::decode(&addr).expect("address is well formed");
+        let (parsed, variant) = crate::decode(&addr).expect("address is well formed");
+
         let mut buf = String::with_capacity(64);
+        let hrp = parsed.hrp();
+        let data = parsed.fe32_iter().collect::<Vec<u5>>();
 
         bh.iter(|| {
             let res =
@@ -1293,10 +454,13 @@ mod benches {
     #[bench]
     fn encode_bech32m_address(bh: &mut Bencher) {
         let addr = "bc1p5d7rjq7g6rdk2yhzks9smlaqtedr4dekq08ge8ztwac72sfr9rusxg3297";
-        let (hrp, data, variant) = crate::decode(&addr).expect("address is well formed");
+        let (parsed, variant) = crate::decode(&addr).expect("address is well formed");
+
+        let hrp = parsed.hrp();
+        let data = parsed.fe32_iter().collect::<Vec<u5>>();
 
         bh.iter(|| {
-            let s = crate::encode(hrp, &data, variant).expect("failed to encode");
+            let s = crate::encode(hrp, &data, variant);
             black_box(&s);
         });
     }
@@ -1305,8 +469,11 @@ mod benches {
     #[bench]
     fn encode_to_fmt_bech32m_address(bh: &mut Bencher) {
         let addr = "bc1p5d7rjq7g6rdk2yhzks9smlaqtedr4dekq08ge8ztwac72sfr9rusxg3297";
-        let (hrp, data, variant) = crate::decode(&addr).expect("address is well formed");
+        let (parsed, variant) = crate::decode(&addr).expect("address is well formed");
+
         let mut buf = String::with_capacity(64);
+        let hrp = parsed.hrp();
+        let data = parsed.fe32_iter().collect::<Vec<u5>>();
 
         bh.iter(|| {
             let res =

--- a/src/primitives/gf32.rs
+++ b/src/primitives/gf32.rs
@@ -185,6 +185,8 @@ impl Fe32 {
         Ok(Fe32(u5))
     }
 
+    pub(crate) fn from_char_unchecked(c: u8) -> Fe32 { Fe32(CHARS_INV[usize::from(c)] as u8) }
+
     /// Converts the field element to a lowercase bech32 character.
     pub fn to_char(self) -> char {
         // Indexing fine as we have self.0 in [0, 32) as an invariant.

--- a/src/primitives/hrp.rs
+++ b/src/primitives/hrp.rs
@@ -16,8 +16,6 @@ use core::fmt::{self, Write};
 use core::iter::FusedIterator;
 use core::slice;
 
-use crate::Case;
-
 /// Maximum length of the human-readable part, as defined by BIP-173.
 const MAX_HRP_LEN: usize = 83;
 
@@ -114,16 +112,6 @@ impl Hrp {
         Ok((new, case))
     }
 
-    /// Lowercase the inner ASCII bytes of this HRP.
-    // This is a hack to support `encode_to_fmt`, we should remove this function.
-    pub(crate) fn lowercase(&mut self) {
-        for b in self.buf.iter_mut() {
-            if is_ascii_uppercase(*b) {
-                *b |= 32;
-            }
-        }
-    }
-
     /// Returns this human-readable part as a lowercase string.
     #[cfg(feature = "alloc")]
     pub fn to_lowercase(&self) -> String { self.lowercase_char_iter().collect() }
@@ -157,6 +145,13 @@ impl Hrp {
 
     /// Always false, the human-readable part is guaranteed to be between 1-83 characters.
     pub fn is_empty(&self) -> bool { false }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Case {
+    Upper,
+    Lower,
+    None,
 }
 
 /// Displays the human-readable part.
@@ -384,7 +379,7 @@ mod tests {
             $(
                 #[test]
                 fn $test_name() {
-                    use crate::Case::*;
+                    use Case::*;
                     let (_, case) = Hrp::parse_and_case($hrp).expect("failed to parse hrp");
                     assert_eq!(case, $expected);
                 }

--- a/src/primitives/hrpstring.rs
+++ b/src/primitives/hrpstring.rs
@@ -1,0 +1,435 @@
+// SPDX-License-Identifier: MIT
+
+//! String encoding/decoding of HRP strings as specified by [BIP-173] (bech32) and [BIP-350] (bech32m).
+//!
+//! HRP string format: `<hrp> 1 <witness_version> <payload> <checksum>`
+//!
+//! * **hrp**: Human Readable Part.
+//! * **witness_version**: 0 ('q) for bech32 1 ('p') for bech32m.
+//! * **payload**: GF(32) bech32 encoded characters.
+//! * **checksum**: BCH code checksum.
+//!
+//! [BIP-173]: <https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki>
+//! [BIP-350]: <https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki>
+
+use core::convert::TryFrom;
+use core::{fmt, iter, slice, str};
+
+use crate::primitives::checksum::{self, Checksum};
+use crate::primitives::gf32::{self, Fe32};
+use crate::primitives::hrp::{self, Hrp};
+use crate::primitives::iter::{Fe32IterExt, FesToBytes};
+use crate::write_err;
+
+/// Separator between the hrp and payload (as defined by BIP-173).
+const SEP: char = '1';
+
+/// An HRP string that has been parsed and had the checksum validated.
+///
+/// Pre-parsing an HRP string only checks validity of the characters, it does not validate the checksum in any way - to validate convert to [`Parsed`].
+#[derive(Debug)]
+pub struct Parsed<'s> {
+    /// The human-readable part, guaranteed to be lowercase ASCII characters.
+    hrp: Hrp,
+    /// The witness version, if one exists.
+    witness_version: Option<u8>,
+    /// This is ASCII byte values of the parsed string, guaranteed to be valid bech32 characters, with the checksum removed.
+    data: &'s [u8],
+}
+
+impl<'s> Parsed<'s> {
+    /// Parses an HRP string, without treating the first data character specially.
+    ///
+    /// Cuidado, if you are doing segwit-y stuff you almost certainly want to use
+    /// [`Parsed::new_with_witness_version`].
+    pub fn new<Ck: Checksum>(s: &'s str) -> Result<Self, Error> {
+        let unvalidated = Parsed::parse_unvalidated(s)?;
+
+        if unvalidated.data.is_empty() {
+            return Err(Error::NothingAfterSeparator);
+        }
+
+        let ret = unvalidated.validate_checksum::<Ck>()?;
+
+        Ok(ret)
+    }
+
+    /// Parses an HRP string, treating the first data character as a witness version.
+    ///
+    /// This version byte does not appear in the extracted binary data, but is covered
+    /// by the checksum. It can be accessed with [`Self::witness_version`] and is also
+    /// returned from this constructor as a convenience.
+    pub fn new_with_witness_version<Ck: Checksum>(s: &'s str) -> Result<(Self, u8), Error> {
+        let mut unvalidated = Parsed::parse_unvalidated(s)?;
+
+        if unvalidated.data.is_empty() {
+            return Err(Error::NothingAfterSeparator);
+        }
+
+        // Unwrap ok since check_characters (in `Self::new`) checked the bech32-ness of this char.
+        let witver = Fe32::from_char(unvalidated.data[0].into()).unwrap().to_u8();
+
+        unvalidated.witness_version = Some(witver);
+        unvalidated.data = &unvalidated.data[1..]; // checksum removed by validation below.
+
+        let ret = unvalidated.validate_checksum::<Ck>()?;
+
+        // From BIP-173:
+        // > Re-arrange those bits into groups of 8 bits. Any incomplete group at the
+        // > end MUST be 4 bits or less, MUST be all zeroes, and is discarded.
+        if ret.data.len() * 5 % 8 > 4 {
+            return Err(Error::InvalidDataLength);
+        }
+
+        Ok((ret, witver))
+    }
+
+    /// Returns the witness version if present.
+    pub fn witness_version(&self) -> Option<u8> { self.witness_version }
+
+    /// Returns the human-readable part.
+    pub fn hrp(&self) -> Hrp { self.hrp }
+
+    /// Returns an iterator over the byte data encoded by the HRP string (excluding the HRP, witness
+    /// version byte if any, and checksum).
+    pub fn byte_iter(&self) -> ByteIter {
+        ByteIter { iter: AsciiToFe32Iter { iter: self.data.iter().copied() }.fes_to_bytes() }
+    }
+
+    /// Returns an iterate over field elements of the data encoded by the HRP string (excluding the
+    /// HRP, witness version byte if any, and checksum).
+    pub fn fe32_iter(&self) -> Fe32Iter {
+        Fe32Iter { iter: AsciiToFe32Iter { iter: self.data.iter().copied() } }
+    }
+
+    /// Parses an bech32 encode string and constructs a [`Parsed`] object that must have
+    /// `validate_checksum` called (if it contains a checksum).
+    ///
+    /// Checks for valid ASCII values, does not validate the checksum.
+    fn parse_unvalidated(s: &'s str) -> Result<Self, Error> {
+        let sep_pos = check_characters(s)?;
+        let (hrp, data) = s.split_at(sep_pos);
+
+        let ret = Parsed {
+            hrp: Hrp::parse(hrp)?,
+            witness_version: None,
+            data: data[1..].as_bytes(), // Skip the separator.
+        };
+
+        Ok(ret)
+    }
+
+    /// Validates that a [`Parsed`] returned by `parse_unvalidated` has a valid checksum.
+    ///
+    /// # Returns
+    ///
+    /// Returns `self` with the checksum removed from the inner data slice.
+    fn validate_checksum<Ck: Checksum>(mut self) -> Result<Self, Error> {
+        if Ck::CHECKSUM_LENGTH == 0 {
+            return Ok(self); // Called with NoChecksum.
+        }
+
+        if self.data.len() < Ck::CHECKSUM_LENGTH {
+            return Err(Error::InvalidChecksumLength);
+        }
+
+        let mut checksum_eng = checksum::Engine::<Ck>::new();
+        checksum_eng.input_hrp(&self.hrp());
+        if let Some(witver) = self.witness_version {
+            checksum_eng.input_fe(Fe32::try_from(witver).map_err(Error::InvalidWitnessVersion)?);
+        }
+        // Unwrap ok since we checked all characters in our constructor.
+        for fe in self.data.iter().map(|&b| Fe32::from_char_unchecked(b)) {
+            checksum_eng.input_fe(fe);
+        }
+
+        if checksum_eng.residue() != &Ck::TARGET_RESIDUE {
+            return Err(Error::InvalidChecksum);
+        }
+
+        let data_len = self.data.len() - Ck::CHECKSUM_LENGTH;
+        self.data = &self.data[..data_len];
+
+        Ok(self)
+    }
+}
+
+/// A iterator over a parsed HRP string data as bytes.
+pub struct ByteIter<'s> {
+    iter: FesToBytes<AsciiToFe32Iter<iter::Copied<slice::Iter<'s, u8>>>>,
+}
+
+impl<'s> Iterator for ByteIter<'s> {
+    type Item = u8;
+    fn next(&mut self) -> Option<u8> { self.iter.next() }
+    fn size_hint(&self) -> (usize, Option<usize>) { self.iter.size_hint() }
+}
+
+/// A iterator over a parsed HRP string data as field elements.
+pub struct Fe32Iter<'s> {
+    iter: AsciiToFe32Iter<iter::Copied<slice::Iter<'s, u8>>>,
+}
+
+impl<'s> Iterator for Fe32Iter<'s> {
+    type Item = Fe32;
+    fn next(&mut self) -> Option<Fe32> { self.iter.next() }
+    fn size_hint(&self) -> (usize, Option<usize>) { self.iter.size_hint() }
+}
+
+/// Helper iterator adaptor that maps an iterator of valid bech32 character ASCII bytes to an
+/// iterator of field elements.
+///
+/// This iterator is a performance optimization. Equivalent, but significantly faster than, using
+/// `hrp_string.data_chk.iter().copied().map(|c| Fe32::from_char_unchecked(c).to_u8())`.
+///
+/// # Panics
+///
+/// If any `u8` in the input iterator is out of range for an [`Fe32`]. Should only be used on data
+/// that has already been checked for validity (eg, by using `check_characters`).
+struct AsciiToFe32Iter<I: Iterator<Item = u8>> {
+    iter: I,
+}
+
+impl<I> Iterator for AsciiToFe32Iter<I>
+where
+    I: Iterator<Item = u8>,
+{
+    type Item = Fe32;
+    fn next(&mut self) -> Option<Fe32> { self.iter.next().map(Fe32::from_char_unchecked) }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        // Each ASCII character is an fe32 so iterators are the same size.
+        self.iter.size_hint()
+    }
+}
+
+/// Checks whether a given HRP string has data characters in the bech32 alphabet (incl. checksum
+/// characters), and that the whole string has consistent casing (hrp, data, and checksum).
+///
+/// # Returns
+///
+/// The byte-index into the string where the '1' separator occurs, or an error if it does not.
+fn check_characters(s: &str) -> Result<usize, Error> {
+    let mut has_upper = false;
+    let mut has_lower = false;
+    let mut req_bech32 = true;
+    let mut sep_pos = None;
+    for (n, ch) in s.char_indices().rev() {
+        if ch == SEP && sep_pos.is_none() {
+            req_bech32 = false;
+            sep_pos = Some(n);
+        }
+        if req_bech32 {
+            Fe32::from_char(ch).map_err(|_| Error::InvalidChar(ch))?;
+        }
+        if ch.is_ascii_uppercase() {
+            has_upper = true;
+        } else if ch.is_ascii_lowercase() {
+            has_lower = true;
+        }
+    }
+    if has_upper && has_lower {
+        Err(Error::MixedCase)
+    } else if let Some(pos) = sep_pos {
+        Ok(pos)
+    } else {
+        Err(Error::MissingSeparator)
+    }
+}
+
+/// Errors types for Bech32 (hrpstring) encoding / decoding.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Error {
+    /// Human-readable part is invalid.
+    InvalidHrp(hrp::Error),
+    /// String does not contain the separator character.
+    MissingSeparator,
+    /// No characters after the separator.
+    NothingAfterSeparator,
+    /// Attempt conversion of an invalid witness version string/number.
+    InvalidWitnessVersion(gf32::Error),
+    /// The data payload is not a valid length.
+    InvalidDataLength,
+    /// The checksum does not match the rest of the data.
+    InvalidChecksum,
+    /// The checksum is not a valid length.
+    InvalidChecksumLength,
+    /// Some part of the string contains an invalid character.
+    InvalidChar(char),
+    /// The whole string must be of one case.
+    MixedCase,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use Error::*;
+
+        match *self {
+            InvalidHrp(ref e) => write_err!(f, "invalid human-readable part"; e),
+            MissingSeparator => write!(f, "missing human-readable separator, \"{}\"", SEP),
+            NothingAfterSeparator => write!(f, "invalid data - no characters after the separator"),
+            InvalidWitnessVersion(ref e) => write_err!(f, "witness version error"; e),
+            InvalidDataLength => write!(f, "invalid data - payload is not a valid length"),
+            InvalidChecksum => write!(f, "invalid checksum"),
+            InvalidChecksumLength => write!(f, "the checksum is not a valid length"),
+            InvalidChar(n) => write!(f, "invalid character (code={})", n),
+            MixedCase => write!(f, "mixed-case strings not allowed"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use Error::*;
+
+        match *self {
+            InvalidHrp(ref e) => Some(e),
+            InvalidWitnessVersion(ref e) => Some(e),
+            MissingSeparator
+            | NothingAfterSeparator
+            | InvalidDataLength
+            | InvalidChecksum
+            | InvalidChecksumLength
+            | InvalidChar(_)
+            | MixedCase => None,
+        }
+    }
+}
+
+impl From<hrp::Error> for Error {
+    fn from(e: hrp::Error) -> Self { Error::InvalidHrp(e) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Bech32, Bech32m};
+
+    #[test]
+    #[allow(unused_variables)] // Triggered by matches macro.
+    fn bip_173_invalid_hrpstring_parsing_fails() {
+        let invalid: Vec<(&str, Error)> = vec!(
+            ("\u{20}1nwldj5",
+             Error::InvalidChar('\u{20}')),
+            ("\u{7F}1axkwrx",
+             Error::InvalidChar('\u{7F}')),
+            ("\u{80}1eym55h",
+             Error::InvalidChar('\u{80}')),
+            ("an84characterslonghumanreadablepartthatcontainsthetheexcludedcharactersbioandnumber11d6pts4",
+             Error::InvalidHrp(hrp::Error::TooLong(84))),
+            ("pzry9x0s0muk",
+             Error::MissingSeparator),
+            ("1pzry9x0s0muk",
+             Error::InvalidHrp(hrp::Error::Empty)),
+            ("x1b4n0q5v",
+             Error::InvalidChar('b')),
+            ("de1lg7wt\u{ff}",
+             Error::InvalidChar('\u{ff}')),
+            ("10a06t8",
+             Error::InvalidHrp(hrp::Error::Empty)),
+            ("1qzzfhee",
+             Error::InvalidHrp(hrp::Error::Empty)),
+        );
+
+        for (s, expected_error) in invalid {
+            assert!(matches!(Parsed::new_with_witness_version::<Bech32>(s), Err(expected_error)));
+            assert!(matches!(Parsed::new::<Bech32>(s), Err(expected_error)));
+        }
+    }
+
+    #[test]
+    #[allow(unused_variables)] // Triggered by matches macro.
+    fn bip_173_invalid_hrpstring_because_of_invalid_checksum() {
+        assert!(matches!(Parsed::new::<Bech32>("li1dgmt3"), Err(Error::InvalidChecksumLength)))
+    }
+
+    #[test]
+    #[allow(unused_variables)] // Triggered by matches macro.
+    fn bip_350_invalid_hrpstring_parsing_fails() {
+        let invalid: Vec<(&str, Error)> = vec!(
+            ("\u{20}1xj0phk",
+             Error::InvalidChar('\u{20}')),
+            ("\u{7F}1g6xzxy",
+             Error::InvalidChar('\u{7F}')),
+            ("\u{80}1g6xzxy",
+             Error::InvalidChar('\u{7F}')),
+            ("an84characterslonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1569pvx",
+             Error::InvalidHrp(hrp::Error::TooLong(84))),
+            ("qyrz8wqd2c9m",
+             Error::MissingSeparator),
+            ("1qyrz8wqd2c9m",
+             Error::InvalidHrp(hrp::Error::Empty)),
+            ("y1b0jsk6g",
+             Error::InvalidChar('b')),
+            ("lt1igcx5c0",
+             Error::InvalidChar('i')),
+            ("mm1crxm3i",
+             Error::InvalidChar('i')),
+            ("au1s5cgom",
+             Error::InvalidChar('o')),
+            ("16plkw9",
+             Error::InvalidHrp(hrp::Error::Empty)),
+            ("1p2gdwpf",
+             Error::InvalidHrp(hrp::Error::Empty)),
+
+        );
+
+        for (s, expected_error) in invalid {
+            assert!(matches!(Parsed::new_with_witness_version::<Bech32m>(s), Err(expected_error)));
+            assert!(matches!(Parsed::new::<Bech32m>(s), Err(expected_error)));
+        }
+    }
+
+    #[test]
+    #[allow(unused_variables)] // Triggered by matches macro.
+    fn bip_350_invalid_hrpstring_because_of_invalid_checksum() {
+        // Note the "bc1p2" test case is not from the bip test vectors.
+        let invalid: Vec<&str> = vec!["in1muywd", "bc1p2"];
+
+        for s in invalid {
+            assert!(matches!(Parsed::new::<Bech32m>(s), Err(Error::InvalidChecksumLength)))
+        }
+    }
+
+    #[test]
+    fn check_hrp_lowercase() {
+        let addr = "bc1zw508d6qejxtdg4y5r3zarvaryvg6kdaj";
+        let (parsed, _) =
+            Parsed::new_with_witness_version::<Bech32>(addr).expect("failed to parse address");
+        assert_eq!(parsed.hrp(), Hrp::parse_unchecked("bc"));
+    }
+
+    #[test]
+    fn check_hrp_uppercase_returns_lower() {
+        let addr = "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4";
+        let parsed = Parsed::new::<Bech32>(addr).expect("failed to parse address");
+        assert_eq!(parsed.hrp(), Hrp::parse_unchecked("bc"));
+    }
+
+    #[test]
+    #[cfg(feature = "alloc")]
+    fn check_hrp_max_length() {
+        let hrps =
+            "an83characterlonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio";
+
+        let hrp = Hrp::parse_unchecked(hrps);
+        let s =
+            crate::encode(hrp, [], crate::Variant::Bech32).expect("failed to encode empty buffer");
+
+        let parsed = Parsed::new::<Bech32>(&s).expect("failed to parse address");
+        assert_eq!(parsed.hrp(), hrp);
+    }
+
+    #[test]
+    fn exclude_strings_that_are_not_valid_bech32_length_0() {
+        let addr = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq";
+        assert!(Parsed::new::<Bech32>(addr).is_ok())
+    }
+
+    #[test]
+    fn exclude_strings_that_are_not_valid_bech32_length_1() {
+        let addr = "23451QAR0SRRR7XFKVY5L643LYDNW9RE59GTZZLKULZK";
+        assert!(Parsed::new::<Bech32>(addr).is_ok())
+    }
+}

--- a/src/primitives/iter.rs
+++ b/src/primitives/iter.rs
@@ -1,0 +1,498 @@
+// SPDX-License-Identifier: MIT
+
+//! Iterator Adaptors
+//!
+//! This module provides iterator adaptors that can be used to verify and generate checksums, HRP
+//! strings, etc., in a variety of ways, without any allocations.
+//!
+//! In general, directly using these adaptors is not very ergonomic, and users are recommended to
+//! instead use the higher-level functions at the root of this crate.
+//!
+//! # Examples
+//!
+//! ```rust
+//! use bech32::{Bech32, ByteIterExt, Fe32IterExt, Fe32, Hrp};
+//!
+//! let witness_prog = [
+//!     0x75, 0x1e, 0x76, 0xe8, 0x19, 0x91, 0x96, 0xd4,
+//!     0x54, 0x94, 0x1c, 0x45, 0xd1, 0xb3, 0xa3, 0x23,
+//!     0xf1, 0x43, 0x3b, 0xd6,
+//! ];
+//!
+//! // You can get a checksum iterator over field elements.
+//! let iter = witness_prog
+//!     .iter()
+//!     .copied()
+//!     .bytes_to_fes()
+//!     .checksummed::<Bech32>()
+//!     .with_witness_version(Fe32::Q); // Optionally add witness version.
+//!
+//! // Or if you have an HRP and witness version.
+//!
+//! let hrp = Hrp::parse_unchecked("bc");
+//! let witness_version = Fe32::Q; // Witness version 0.
+//!
+//! let iterator = witness_prog
+//!     .iter()
+//!     .copied()
+//!     .bytes_to_fes()
+//!     .hrp_checksummed::<Bech32>(&hrp, witness_version) // Converts to an `HrpChecksummed`
+//!     .hrpstring_chars();
+//! let hrpstring: String = iterator.collect();
+//! assert_eq!(hrpstring.to_uppercase(), "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4");
+//! ```
+
+use crate::primitives::checksum::{self, Checksum, PackedFe32};
+use crate::primitives::gf32::Fe32;
+use crate::primitives::hrp::{self, Hrp};
+
+/// Extension trait for byte iterators which provides an adaptor to GF32 elements.
+pub trait ByteIterExt: Sized + Iterator<Item = u8> {
+    /// Adapts the byte iterator to output GF32 field elements instead.
+    ///
+    /// If the total number of bits is not a multiple of 5 we pad with 0s
+    fn bytes_to_fes(mut self) -> BytesToFes<Self> {
+        BytesToFes { last_byte: self.next(), bit_offset: 0, iter: self }
+    }
+}
+
+impl<I> ByteIterExt for I where I: Iterator<Item = u8> {}
+
+/// Extension trait for field element iterators.
+pub trait Fe32IterExt: Sized + Iterator<Item = Fe32> {
+    /// Adapts the `Fe32` iterator to output bytes instead.
+    ///
+    /// If the total number of bits is not a multiple of 8, any trailing bits
+    /// are simply dropped.
+    fn fes_to_bytes(mut self) -> FesToBytes<Self> {
+        FesToBytes { last_fe: self.next(), bit_offset: 0, iter: self }
+    }
+
+    /// Adapts the Fe32 data iterator using `hrp` and `witness_version`, and then appends a checksum.
+    fn hrp_checksummed<Ck: Checksum>(
+        self,
+        hrp: &Hrp,
+        witness_version: Fe32,
+    ) -> HrpChecksummed<Self, Ck> {
+        Checksummed::new(self).with_witness_version(witness_version).hrp_checksummed(hrp)
+    }
+
+    /// Adapts the Fe32 iterator to append a checksum to the end of the data.
+    fn checksummed<Ck: Checksum>(self) -> Checksummed<Self, Ck> { Checksummed::new(self) }
+}
+
+impl<I> Fe32IterExt for I where I: Iterator<Item = Fe32> {}
+
+/// Iterator adaptor that converts bytes to GF32 elements.
+///
+/// If the total number of bits is not a multiple of 5, it right-pads with 0 bits.
+#[derive(Clone, PartialEq, Eq)]
+pub struct BytesToFes<I: Iterator<Item = u8>> {
+    last_byte: Option<u8>,
+    bit_offset: usize,
+    iter: I,
+}
+
+impl<I> Iterator for BytesToFes<I>
+where
+    I: Iterator<Item = u8>,
+{
+    type Item = Fe32;
+
+    fn next(&mut self) -> Option<Fe32> {
+        use core::cmp::Ordering::*;
+
+        let bit_offset = {
+            let ret = self.bit_offset;
+            self.bit_offset = (self.bit_offset + 5) % 8;
+            ret
+        };
+
+        if let Some(last) = self.last_byte {
+            match bit_offset.cmp(&3) {
+                Less => Some(Fe32((last >> (3 - bit_offset)) & 0x1f)),
+                Equal => {
+                    self.last_byte = self.iter.next();
+                    Some(Fe32(last & 0x1f))
+                }
+                Greater => {
+                    self.last_byte = self.iter.next();
+                    let next = self.last_byte.unwrap_or(0);
+                    Some(Fe32(((last << (bit_offset - 3)) | (next >> (11 - bit_offset))) & 0x1f))
+                }
+            }
+        } else {
+            None
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (min, max) = self.iter.size_hint();
+        let (min, max) = match self.last_byte {
+            // +1 because we set last_byte with call to `next`.
+            Some(_) => (min + 1, max.map(|max| max + 1)),
+            None => (min, max),
+        };
+
+        let min = bytes_len_to_fes_len(min);
+        let max = max.map(bytes_len_to_fes_len);
+
+        (min, max)
+    }
+}
+
+/// The number of fes encoded by n bytes, rounded up because we pad the fes.
+fn bytes_len_to_fes_len(bytes: usize) -> usize {
+    let bits = bytes * 8;
+    (bits + 4) / 5
+}
+
+/// Iterator adaptor that converts GF32 elements to bytes.
+///
+/// If the total number of bits is not a multiple of 8, any trailing bits are dropped.
+///
+/// Note that if there are 5 or more trailing bits, the result will be that an entire field element
+/// is dropped. If this occurs, the input was an invalid length for a bech32 string, but this
+/// iterator does not do any checks for this.
+#[derive(Clone, PartialEq, Eq)]
+pub struct FesToBytes<I: Iterator<Item = Fe32>> {
+    last_fe: Option<Fe32>,
+    bit_offset: usize,
+    iter: I,
+}
+
+impl<I> Iterator for FesToBytes<I>
+where
+    I: Iterator<Item = Fe32>,
+{
+    type Item = u8;
+
+    fn next(&mut self) -> Option<u8> {
+        let bit_offset = {
+            let ret = self.bit_offset;
+            self.bit_offset = (self.bit_offset + 8) % 5;
+            ret
+        };
+
+        if let Some(last) = self.last_fe {
+            let mut ret = last.0 << (3 + bit_offset);
+
+            self.last_fe = self.iter.next();
+            let next1 = self.last_fe?;
+            if bit_offset > 2 {
+                self.last_fe = self.iter.next();
+                let next2 = self.last_fe?;
+                ret |= next1.0 << (bit_offset - 2);
+                ret |= next2.0 >> (7 - bit_offset);
+            } else {
+                ret |= next1.0 >> (2 - bit_offset);
+                if self.bit_offset == 0 {
+                    self.last_fe = self.iter.next();
+                }
+            }
+
+            Some(ret)
+        } else {
+            None
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        // If the total number of bits is not a multiple of 8, any trailing bits are dropped.
+        let fes_len_to_bytes_len = |n| n * 5 / 8;
+
+        let (fes_min, fes_max) = self.iter.size_hint();
+        // +1 because we set last_fe with call to `next`.
+        let min = fes_len_to_bytes_len(fes_min) + 1;
+        let max = fes_max.map(|max| fes_len_to_bytes_len(max) + 1);
+        (min, max)
+    }
+}
+
+/// Iterator adaptor for field-element-yielding iterator, which tacks a checksum onto the end of the
+/// yielded data.
+#[derive(Clone, PartialEq, Eq)]
+pub struct Checksummed<I, Ck>
+where
+    I: Iterator<Item = Fe32>,
+    Ck: Checksum,
+{
+    witness_version: Option<Fe32>,
+    iter: I,
+    checksum_remaining: usize,
+    checksum_engine: checksum::Engine<Ck>,
+}
+
+impl<I, Ck> Checksummed<I, Ck>
+where
+    I: Iterator<Item = Fe32>,
+    Ck: Checksum,
+{
+    /// Creates a new checksummed iterator which adapts a data iterator of field elements by
+    /// appending a checksum.
+    pub fn new(data: I) -> Checksummed<I, Ck> {
+        Checksummed {
+            witness_version: None,
+            iter: data,
+            checksum_remaining: Ck::CHECKSUM_LENGTH,
+            checksum_engine: checksum::Engine::new(),
+        }
+    }
+
+    /// Adapts a [`Checksummed`] iterator by prepending a witness version.
+    ///
+    /// Must be called before the `Checksummed` iterator has yielded any results.
+    pub fn with_witness_version(mut self, witness_version: Fe32) -> Checksummed<I, Ck> {
+        self.witness_version = Some(witness_version);
+        self
+    }
+
+    /// Adapts a [`Checksummed`] iterator into an `HrpChecksummed` iterator.
+    ///
+    /// Must be called before the `Checksummed` iterator has yielded any results.
+    pub fn hrp_checksummed(self, hrp: &Hrp) -> HrpChecksummed<I, Ck> {
+        HrpChecksummed::new(hrp, self)
+    }
+}
+
+impl<I, Ck> Iterator for Checksummed<I, Ck>
+where
+    I: Iterator<Item = Fe32>,
+    Ck: Checksum,
+{
+    type Item = Fe32;
+
+    fn next(&mut self) -> Option<Fe32> {
+        if let Some(witness_version) = self.witness_version {
+            self.witness_version = None;
+            self.checksum_engine.input_fe(witness_version);
+            return Some(witness_version);
+        }
+
+        match self.iter.next() {
+            Some(fe) => {
+                self.checksum_engine.input_fe(fe);
+                Some(fe)
+            }
+            None =>
+                if self.checksum_remaining == 0 {
+                    None
+                } else {
+                    if self.checksum_remaining == Ck::CHECKSUM_LENGTH {
+                        self.checksum_engine.input_target_residue();
+                    }
+                    self.checksum_remaining -= 1;
+                    Some(Fe32(self.checksum_engine.residue().unpack(self.checksum_remaining)))
+                },
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let wit = match self.witness_version {
+            Some(_) => 1,
+            None => 0,
+        };
+        let add = wit + self.checksum_remaining;
+        let (min, max) = self.iter.size_hint();
+
+        (min + add, max.map(|max| max + add))
+    }
+}
+
+/// Iterator adaptor for a checksummed iterator that inputs the HRP into the checksum algorithm
+/// before yielding the data followed by the checksum.
+#[derive(Clone, PartialEq, Eq)]
+pub struct HrpChecksummed<'hrp, I, Ck>
+where
+    I: Iterator<Item = Fe32>,
+    Ck: Checksum,
+{
+    /// The HRP to input into the checksum algorithm.
+    hrp: &'hrp Hrp,
+    /// A field element iterator with or without the witness version.
+    iter: Checksummed<I, Ck>,
+}
+
+impl<'hrp, I, Ck> HrpChecksummed<'hrp, I, Ck>
+where
+    I: Iterator<Item = Fe32>,
+    Ck: Checksum,
+{
+    /// Adapts an checksummed iterator by inputting the HRP to the checksum algorithm.
+    ///
+    /// `iter` may or may not include the witness version.
+    pub fn new(hrp: &'hrp Hrp, mut iter: Checksummed<I, Ck>) -> HrpChecksummed<'hrp, I, Ck> {
+        iter.checksum_engine.input_hrp(hrp);
+        Self { hrp, iter }
+    }
+
+    /// Adapts the iterator to yield characters representing the bech32 encoding.
+    pub fn hrpstring_chars(self) -> HrpstringChars<'hrp, I, Ck> { HrpstringChars::new(self) }
+}
+
+impl<'hrp, I, Ck> Iterator for HrpChecksummed<'hrp, I, Ck>
+where
+    I: Iterator<Item = Fe32>,
+    Ck: Checksum,
+{
+    type Item = Fe32;
+    fn next(&mut self) -> Option<Fe32> { self.iter.next() }
+    fn size_hint(&self) -> (usize, Option<usize>) { self.iter.size_hint() }
+}
+
+/// Iterator adaptor which takes a stream of field elements, converts it to characters prefixed by
+/// an HRP (and separator), and suffixed by the checksum i.e., converts the data in a stream of
+/// field elements into stream of characters representing the encoded bech32 string.
+pub struct HrpstringChars<'hrp, I, Ck>
+where
+    I: Iterator<Item = Fe32>,
+    Ck: Checksum,
+{
+    /// `None` once the hrp has been yielded.
+    hrp_iter: Option<hrp::LowercaseCharIter<'hrp>>,
+    /// Iterator over field elements made up of the optional witness version, the data to be
+    /// encoded, plus the checksum.
+    checksummed: HrpChecksummed<'hrp, I, Ck>,
+}
+
+impl<'hrp, I, Ck> HrpstringChars<'hrp, I, Ck>
+where
+    I: Iterator<Item = Fe32>,
+    Ck: Checksum,
+{
+    /// Adapts the `HrpChecksummed` iterator to yield characters representing the bech32 encoding.
+    pub fn new(checksummed: HrpChecksummed<'hrp, I, Ck>) -> Self {
+        Self { hrp_iter: Some(checksummed.hrp.lowercase_char_iter()), checksummed }
+    }
+}
+
+impl<'a, I, Ck> Iterator for HrpstringChars<'a, I, Ck>
+where
+    I: Iterator<Item = Fe32>,
+    Ck: Checksum,
+{
+    type Item = char;
+
+    fn next(&mut self) -> Option<char> {
+        if let Some(ref mut hrp_iter) = self.hrp_iter {
+            match hrp_iter.next() {
+                Some(c) => return Some(c),
+                None => {
+                    self.hrp_iter = None;
+                    return Some('1');
+                }
+            }
+        }
+
+        self.checksummed.next().map(|fe| fe.to_char())
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match &self.hrp_iter {
+            // We have yielded the hrp and separator already.
+            None => self.checksummed.size_hint(),
+            // Yet to finish yielding the hrp (and the separator).
+            Some(hrp_iter) => {
+                let (hrp_min, hrp_max) = hrp_iter.size_hint();
+                let (chk_min, chk_max) = self.checksummed.size_hint();
+
+                let min = hrp_min + 1 + chk_min; // +1 for the separator.
+
+                // To provide a max boundary we need to have gotten a value from the hrp iter as well as the
+                // checksummed iter, otherwise we have to return None since we cannot know the maximum.
+                let max = match (hrp_max, chk_max) {
+                    (Some(hrp_max), Some(chk_max)) => Some(hrp_max + 1 + chk_max),
+                    (_, _) => None,
+                };
+
+                (min, max)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Bech32;
+
+    // Tests below using this data, are based on the test vector (from BIP-173):
+    // BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4: 0014751e76e8199196d454941c45d1b3a323f1433bd6
+    #[rustfmt::skip]
+    const DATA: [u8; 20] = [
+        0x75, 0x1e, 0x76, 0xe8, 0x19, 0x91, 0x96, 0xd4,
+        0x54, 0x94, 0x1c, 0x45, 0xd1, 0xb3, 0xa3, 0x23,
+        0xf1, 0x43, 0x3b, 0xd6,
+    ];
+
+    #[test]
+    fn byte_iter_ext() {
+        assert!(DATA
+            .iter()
+            .copied()
+            .bytes_to_fes()
+            .map(Fe32::to_char)
+            .eq("w508d6qejxtdg4y5r3zarvary0c5xw7k".chars()));
+    }
+
+    #[test]
+    fn bytes_to_fes_size_hint() {
+        let char_len = "w508d6qejxtdg4y5r3zarvary0c5xw7k".len();
+        assert_eq!(DATA.iter().copied().bytes_to_fes().size_hint(), (char_len, Some(char_len)));
+    }
+
+    #[test]
+    fn fe32_iter_ext() {
+        let fe_iter = "w508d6qejxtdg4y5r3zarvary0c5xw7k"
+            .bytes()
+            .map(|b| Fe32::from_char(char::from(b)).unwrap());
+
+        assert!(fe_iter.clone().fes_to_bytes().eq(DATA.iter().copied()));
+    }
+
+    #[test]
+    fn fes_to_bytes_size_hint() {
+        let fe_iter = "w508d6qejxtdg4y5r3zarvary0c5xw7k"
+            .bytes()
+            .map(|b| Fe32::from_char(char::from(b)).unwrap());
+
+        let got_hint = fe_iter.clone().fes_to_bytes().size_hint();
+        let want_hint = DATA.iter().size_hint();
+
+        assert_eq!(got_hint, want_hint)
+    }
+
+    #[test]
+    fn hrpstring_iter() {
+        let iter = DATA.iter().copied().bytes_to_fes();
+
+        let hrp = Hrp::parse_unchecked("bc");
+        let iter = iter.hrp_checksummed::<Bech32>(&hrp, Fe32::Q).hrpstring_chars();
+
+        assert!(iter.eq("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4".chars()));
+    }
+
+    #[test]
+    #[cfg(feature = "alloc")]
+    fn hrpstring_iter_collect() {
+        let iter = DATA.iter().copied().bytes_to_fes();
+
+        let hrp = Hrp::parse_unchecked("bc");
+        let iter = iter.hrp_checksummed::<Bech32>(&hrp, Fe32::Q).hrpstring_chars();
+
+        let encoded = iter.collect::<String>();
+        assert_eq!(encoded, "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4");
+    }
+
+    #[test]
+    fn hrpstring_iter_size_hint() {
+        let char_len = "w508d6qejxtdg4y5r3zarvary0c5xw7k".len();
+        let iter = DATA.iter().copied().bytes_to_fes();
+
+        let hrp = Hrp::parse_unchecked("bc");
+        let iter = iter.hrp_checksummed::<Bech32>(&hrp, Fe32::Q).hrpstring_chars();
+
+        let checksummed_len = 2 + 1 + 1 + char_len + 6; // bc + SEP + Q + chars + checksum
+        assert_eq!(iter.size_hint().0, checksummed_len);
+    }
+}

--- a/src/primitives/mod.rs
+++ b/src/primitives/mod.rs
@@ -5,6 +5,8 @@
 pub mod checksum;
 pub mod gf32;
 pub mod hrp;
+pub mod hrpstring;
+pub mod iter;
 
 use checksum::{Checksum, PackedNull};
 


### PR DESCRIPTION
(Just the last patch, the rest is in #116)

Currently there are a bunch of types and traits in `lib.rs` for converting to/from base32 (incl. doing so without allocating).

Observe that instead of custom types we can use iterator adapters to achieve this. Some benefits are:

- More composabality
- More "rusty"
- Uses the new `checksum` module (i.e, better separation of concerns)
- Hopefully more maintainable

Add two new sub-modules to the `primitives` module:

- `iter`: Implement various adaptor iterators for allocationless checksumming etc.
- `hrpstring`: Add the `Parsed` struct that can be used for parsing bech32 address strings.

Remove everything that is now not needed from `lib.rs` while making an effort not to change the API too much i.e., keep the current public functions more or less as they are, with the following notable exceptions:

- `encode_to_fmt` no longer returns a result
- `encode` now returns a `fmt::Error` as the `Result` error variant (instead of `Error`).
- `decode` returns a `Parsed` instead of an HRP and vector of u5s, to get the HRP/u5's one can use the `hrp()` and `fe32_iter()` functions on `Parsed`.
- `decode_without_checksum` return value changed as per `decode`.
- The crate level `Error` type is totally re-written.

All the recently added but as-yet-unreleased `arrayvec` stuff which was added to improve alloc free encoding/decoding is removed.

## Complete list of the public types/functions removed in this patch

(This functionality is now provided by `primitives`.)

- traits:
  - `WriteBase32`
  - `WriteBase256` (unreleased)
  - `FromBase32`
  - `ToBase32`
  - `Base32Len`
  - `CheckBase32`

- types (and their trait implementations):
  - `Bech32Writer`
  - `ComboError` (unreleased)
  - `Case` (exist still but is private)

- functions:
  - `convert_bits`
  - `convert_bits_in` (unreleased)
  - `encode_to_fmt_anycase` (unreleased)
  - `decode_lowercase` (unreleased)

