### PR TITLE
Remove custom implementation of `ExactSizeIterator`

### DIFF
--- a/src/primitives/hrp.rs
+++ b/src/primitives/hrp.rs
@@ -210,9 +210,7 @@ impl<'b> Iterator for ByteIter<'b> {
     fn size_hint(&self) -> (usize, Option<usize>) { self.iter.size_hint() }
 }
 
-impl<'b> ExactSizeIterator for ByteIter<'b> {
-    fn len(&self) -> usize { self.iter.len() }
-}
+impl<'b> ExactSizeIterator for ByteIter<'b> {}
 
 impl<'b> DoubleEndedIterator for ByteIter<'b> {
     fn next_back(&mut self) -> Option<Self::Item> { self.iter.next_back().copied() }
@@ -233,9 +231,7 @@ impl<'b> Iterator for CharIter<'b> {
     fn size_hint(&self) -> (usize, Option<usize>) { self.iter.size_hint() }
 }
 
-impl<'b> ExactSizeIterator for CharIter<'b> {
-    fn len(&self) -> usize { self.iter.len() }
-}
+impl<'b> ExactSizeIterator for CharIter<'b> {}
 
 impl<'b> DoubleEndedIterator for CharIter<'b> {
     fn next_back(&mut self) -> Option<Self::Item> { self.iter.next_back().map(Into::into) }
@@ -256,9 +252,7 @@ impl<'b> Iterator for LowercaseByteIter<'b> {
     fn size_hint(&self) -> (usize, Option<usize>) { self.iter.size_hint() }
 }
 
-impl<'b> ExactSizeIterator for LowercaseByteIter<'b> {
-    fn len(&self) -> usize { self.iter.len() }
-}
+impl<'b> ExactSizeIterator for LowercaseByteIter<'b> {}
 
 impl<'b> DoubleEndedIterator for LowercaseByteIter<'b> {
     fn next_back(&mut self) -> Option<Self::Item> {
@@ -279,9 +273,7 @@ impl<'b> Iterator for LowercaseCharIter<'b> {
     fn size_hint(&self) -> (usize, Option<usize>) { self.iter.size_hint() }
 }
 
-impl<'b> ExactSizeIterator for LowercaseCharIter<'b> {
-    fn len(&self) -> usize { self.iter.len() }
-}
+impl<'b> ExactSizeIterator for LowercaseCharIter<'b> {}
 
 impl<'b> DoubleEndedIterator for LowercaseCharIter<'b> {
     fn next_back(&mut self) -> Option<Self::Item> { self.iter.next_back().map(Into::into) }

--- a/src/primitives/hrp.rs
+++ b/src/primitives/hrp.rs
@@ -207,7 +207,7 @@ pub struct ByteIter<'b> {
 impl<'b> Iterator for ByteIter<'b> {
     type Item = u8;
     fn next(&mut self) -> Option<u8> { self.iter.next().copied() }
-    fn size_hint(&self) -> (usize, Option<usize>) { (self.len(), Some(self.len())) }
+    fn size_hint(&self) -> (usize, Option<usize>) { self.iter.size_hint() }
 }
 
 impl<'b> ExactSizeIterator for ByteIter<'b> {
@@ -230,7 +230,7 @@ pub struct CharIter<'b> {
 impl<'b> Iterator for CharIter<'b> {
     type Item = char;
     fn next(&mut self) -> Option<char> { self.iter.next().map(Into::into) }
-    fn size_hint(&self) -> (usize, Option<usize>) { (self.len(), Some(self.len())) }
+    fn size_hint(&self) -> (usize, Option<usize>) { self.iter.size_hint() }
 }
 
 impl<'b> ExactSizeIterator for CharIter<'b> {
@@ -253,7 +253,7 @@ impl<'b> Iterator for LowercaseByteIter<'b> {
     fn next(&mut self) -> Option<u8> {
         self.iter.next().map(|b| if is_ascii_uppercase(b) { b | 32 } else { b })
     }
-    fn size_hint(&self) -> (usize, Option<usize>) { (self.len(), Some(self.len())) }
+    fn size_hint(&self) -> (usize, Option<usize>) { self.iter.size_hint() }
 }
 
 impl<'b> ExactSizeIterator for LowercaseByteIter<'b> {
@@ -276,7 +276,7 @@ pub struct LowercaseCharIter<'b> {
 impl<'b> Iterator for LowercaseCharIter<'b> {
     type Item = char;
     fn next(&mut self) -> Option<char> { self.iter.next().map(Into::into) }
-    fn size_hint(&self) -> (usize, Option<usize>) { (self.len(), Some(self.len())) }
+    fn size_hint(&self) -> (usize, Option<usize>) { self.iter.size_hint() }
 }
 
 impl<'b> ExactSizeIterator for LowercaseCharIter<'b> {

--- a/src/primitives/hrp.rs
+++ b/src/primitives/hrp.rs
@@ -207,7 +207,6 @@ pub struct ByteIter<'b> {
 impl<'b> Iterator for ByteIter<'b> {
     type Item = u8;
     fn next(&mut self) -> Option<u8> { self.iter.next().copied() }
-
     fn size_hint(&self) -> (usize, Option<usize>) { (self.len(), Some(self.len())) }
 }
 
@@ -231,7 +230,6 @@ pub struct CharIter<'b> {
 impl<'b> Iterator for CharIter<'b> {
     type Item = char;
     fn next(&mut self) -> Option<char> { self.iter.next().map(Into::into) }
-
     fn size_hint(&self) -> (usize, Option<usize>) { (self.len(), Some(self.len())) }
 }
 
@@ -255,7 +253,6 @@ impl<'b> Iterator for LowercaseByteIter<'b> {
     fn next(&mut self) -> Option<u8> {
         self.iter.next().map(|b| if is_ascii_uppercase(b) { b | 32 } else { b })
     }
-
     fn size_hint(&self) -> (usize, Option<usize>) { (self.len(), Some(self.len())) }
 }
 
@@ -279,7 +276,6 @@ pub struct LowercaseCharIter<'b> {
 impl<'b> Iterator for LowercaseCharIter<'b> {
     type Item = char;
     fn next(&mut self) -> Option<char> { self.iter.next().map(Into::into) }
-
     fn size_hint(&self) -> (usize, Option<usize>) { (self.len(), Some(self.len())) }
 }
 


### PR DESCRIPTION
Draft because includes #114 (first 2 patches).

From the docs [0]

> The len method has a default implementation, so you usually shouldn’t
> implement it. However, you may be able to provide a more performant
> implementation than the default, so overriding it in this case makes
> sense.

Our current implementations do nothing but call through to the inner iterator's `len` method which is not a performance improvement so is contrary to the remarks above.

Remove the implementations of `ExactSizeIterator` using the default impl instead.

[0] https://doc.rust-lang.org/std/iter/trait.ExactSizeIterator.html