### PR TITLE
Do random improvements

### DIFF
--- a/embedded/no-allocator/src/main.rs
+++ b/embedded/no-allocator/src/main.rs
@@ -7,12 +7,11 @@
 #![no_main]
 #![no_std]
 
-use panic_halt as _;
-
 use arrayvec::{ArrayString, ArrayVec};
-use bech32::{self, u5, ComboError, FromBase32, ToBase32, Variant, Hrp};
+use bech32::{self, u5, ComboError, FromBase32, Hrp, ToBase32, Variant};
 use cortex_m_rt::entry;
 use cortex_m_semihosting::{debug, hprintln};
+use panic_halt as _;
 
 // Note: `#[global_allocator]` is NOT set.
 
@@ -26,9 +25,7 @@ fn main() -> ! {
 
     let hrp = Hrp::parse("bech32").unwrap();
 
-    bech32::encode_to_fmt_anycase(&mut encoded, hrp, &base32, Variant::Bech32)
-        .unwrap()
-        .unwrap();
+    bech32::encode_to_fmt_anycase(&mut encoded, hrp, &base32, Variant::Bech32).unwrap().unwrap();
     test(&*encoded == "bech321qqqsyrhqy2a");
 
     hprintln!("{}", encoded).unwrap();

--- a/embedded/with-allocator/src/main.rs
+++ b/embedded/with-allocator/src/main.rs
@@ -3,18 +3,18 @@
 #![no_std]
 
 extern crate alloc;
+use core::alloc::Layout;
+
+use alloc_cortex_m::CortexMHeap;
+use bech32::{self, FromBase32, Hrp, ToBase32, Variant};
+use cortex_m::asm;
+use cortex_m_rt::entry;
+use cortex_m_semihosting::{debug, hprintln};
 use panic_halt as _;
 
 use self::alloc::string::ToString;
 use self::alloc::vec;
 use self::alloc::vec::Vec;
-use core::alloc::Layout;
-
-use alloc_cortex_m::CortexMHeap;
-use bech32::{self, FromBase32, ToBase32, Variant, Hrp};
-use cortex_m::asm;
-use cortex_m_rt::entry;
-use cortex_m_semihosting::{debug, hprintln};
 
 #[global_allocator]
 static ALLOCATOR: CortexMHeap = CortexMHeap::empty();
@@ -27,12 +27,7 @@ fn main() -> ! {
     unsafe { ALLOCATOR.init(cortex_m_rt::heap_start() as usize, HEAP_SIZE) }
 
     let hrp = Hrp::parse("bech32").unwrap();
-    let encoded = bech32::encode(
-        hrp,
-        vec![0x00, 0x01, 0x02].to_base32(),
-        Variant::Bech32,
-    )
-    .unwrap();
+    let encoded = bech32::encode(hrp, vec![0x00, 0x01, 0x02].to_base32(), Variant::Bech32).unwrap();
     test(encoded == "bech321qqqsyrhqy2a".to_string());
 
     hprintln!("{}", encoded).unwrap();

--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -47,3 +47,6 @@ git diff-index --check --cached $against -- || exit 1
 
 # Check that code lints cleanly.
 cargo clippy --all-features -- -D warnings || exit 1
+
+# Check that there are no formatting issues.
+cargo +nightly fmt --check || exit 1

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,6 @@
 // Written by the Rust Bitcoin developers.
 // SPDX-License-Identifier: CC0-1.0
 
-// TODO: We can get this from `bitcoin-internals` crate once that is released.
-
 //! # Error
 //!
 //! Error handling macros and helpers.

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,10 +1,4 @@
-// Written by the Rust Bitcoin developers.
 // SPDX-License-Identifier: CC0-1.0
-
-//! # Error
-//!
-//! Error handling macros and helpers.
-//!
 
 /// Formats error.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -434,9 +434,8 @@ pub fn encode_to_fmt_anycase<T: AsRef<[u5]>>(
 ///
 /// This method is intended for implementing traits from [`std::fmt`].
 ///
-/// # Errors
+/// # Deviations from standard.
 ///
-/// * Deviations from standard.
 /// * No length limits are enforced for the data part.
 pub fn encode_without_checksum_to_fmt<T: AsRef<[u5]>>(
     fmt: &mut dyn fmt::Write,
@@ -484,9 +483,8 @@ impl Variant {
 
 /// Encodes a bech32 payload to string.
 ///
-/// # Errors
+/// # Deviations from standard.
 ///
-/// * Deviations from standard.
 /// * No length limits are enforced for the data part.
 #[cfg(feature = "alloc")]
 pub fn encode<T: AsRef<[u5]>>(hrp: Hrp, data: T, variant: Variant) -> Result<String, Error> {
@@ -497,9 +495,8 @@ pub fn encode<T: AsRef<[u5]>>(hrp: Hrp, data: T, variant: Variant) -> Result<Str
 
 /// Encodes a bech32 payload to string without the checksum.
 ///
-/// # Errors
+/// # Deviations from standard.
 ///
-/// * Deviations from standard.
 /// * No length limits are enforced for the data part.
 #[cfg(feature = "alloc")]
 pub fn encode_without_checksum<T: AsRef<[u5]>>(hrp: Hrp, data: T) -> Result<String, Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,24 +11,6 @@
 //!
 //! The original description in [BIP-0173](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki)
 //! has more details. See also [BIP-0350](https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki).
-//!
-#![cfg_attr(
-    feature = "std",
-    doc = "
-# Examples
-```
-use bech32::{self, FromBase32, ToBase32, Variant, Hrp};
-let hrp = Hrp::parse(\"bech32\").expect(\"bech32 is valid\");
-let encoded = bech32::encode(hrp, vec![0x00, 0x01, 0x02].to_base32(), Variant::Bech32).unwrap();
-assert_eq!(encoded, \"bech321qqqsyrhqy2a\".to_string());
-let (hrp, data, variant) = bech32::decode(&encoded).unwrap();
-assert_eq!(hrp.to_string(), \"bech32\");
-assert_eq!(Vec::<u8>::from_base32(&data).unwrap(), vec![0x00, 0x01, 0x02]);
-assert_eq!(variant, Variant::Bech32);
-```
-"
-)]
-//!
 
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
 // Experimental features we need.


### PR DESCRIPTION
Pull all the unrelated random improvements out of #113 so that we can review/merge them more easily. Nothing controversial here except perhaps commit: `a2209d5 Remove crate level examples`. Note also that commit: `1a746b7 Clean up comments in private error module` is new.