### PR TITLE
Remove unreleased "arrayvec" code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,5 @@ default = ["std"]
 std = ["alloc"]
 alloc = []
 
-[dependencies.arrayvec]
-version = "0.7.1"
-default-features = false
-optional = true
-
 [target.'cfg(mutate)'.dev-dependencies]
 mutagen = { git = "https://github.com/llogiq/mutagen" }

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -48,12 +48,6 @@ if [ "${DO_FEATURE_MATRIX-false}" = true ]; then
     build_and_test "std"
     build_and_test "alloc"
     build_and_test "std alloc"
-    # arrayvec breaks the MSRV
-    if [ $MSRV = false ]; then
-        build_and_test "arrayvec"
-        build_and_test "std arrayvec"
-        build_and_test "alloc arrayvec"
-    fi
 fi
 
 # Build the docs if told to (this only works with the nightly toolchain)

--- a/embedded/no-allocator/Cargo.toml
+++ b/embedded/no-allocator/Cargo.toml
@@ -11,7 +11,7 @@ cortex-m-rt = "0.6.10"
 cortex-m-semihosting = "0.3.3"
 panic-halt = "0.2.0"
 arrayvec = { version = "0.7.1", default-features = false }
-bech32 = { path = "../../", default-features = false, features = ["arrayvec"] }
+bech32 = { path = "../../", default-features = false }
 
 [[bin]]
 name = "no-allocator"

--- a/embedded/no-allocator/src/main.rs
+++ b/embedded/no-allocator/src/main.rs
@@ -1,6 +1,6 @@
 //! Test `no_std` build of `bech32`.
 //!
-//! Build with: `cargo rustc -- -C link-arg=-nostartfiles`.
+//! Build with: `cargo +nightly rustc -- -C link-arg=-nostartfiles`.
 //!
 
 #![feature(alloc_error_handler)]

--- a/embedded/no-allocator/src/main.rs
+++ b/embedded/no-allocator/src/main.rs
@@ -8,7 +8,8 @@
 #![no_std]
 
 use arrayvec::{ArrayString, ArrayVec};
-use bech32::{self, u5, ComboError, FromBase32, Hrp, ToBase32, Variant};
+use bech32::{self, u5, Hrp, Variant, ByteIterExt, Bech32};
+use bech32::primitives::decode::CheckedHrpstring;
 use cortex_m_rt::entry;
 use cortex_m_semihosting::{debug, hprintln};
 use panic_halt as _;
@@ -19,9 +20,7 @@ use panic_halt as _;
 fn main() -> ! {
     let mut encoded = ArrayString::<30>::new();
 
-    let mut base32 = ArrayVec::<u5, 30>::new();
-
-    [0x00u8, 0x01, 0x02].write_base32(&mut base32).unwrap();
+    let base32 = [0x00u8, 0x01, 0x02].iter().copied().bytes_to_fes().collect::<ArrayVec<u5, 30>>();
 
     let hrp = Hrp::parse("bech32").unwrap();
 
@@ -30,16 +29,11 @@ fn main() -> ! {
 
     hprintln!("{}", encoded).unwrap();
 
-    let mut decoded = ArrayVec::<u5, 30>::new();
+    let unchecked = CheckedHrpstring::new::<Bech32>(&encoded).unwrap();
 
-    let mut scratch = ArrayVec::<u5, 30>::new();
-
-    let (got_hrp, data, variant) =
-        bech32::decode_lowercase::<ComboError, _, _>(&encoded, &mut decoded, &mut scratch).unwrap();
-    test(got_hrp == hrp);
-    let res = ArrayVec::<u8, 30>::from_base32(&data).unwrap();
+    test(unchecked.hrp() == hrp);
+    let res = unchecked.byte_iter().collect::<ArrayVec<u8, 30>>();
     test(&res == [0x00, 0x01, 0x02].as_ref());
-    test(variant == Variant::Bech32);
 
     debug::exit(debug::EXIT_SUCCESS);
 


### PR DESCRIPTION
Modify the embedded no-allocator test to use the new `primitives` module, once that is done we can remove all the code feature gated on "arrayvec" that was recently added (and unreleased) to support allocationless encoding/decoding.