### PR TITLE
Release v0.10.0-alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-# unreleased (0.10.0)
+# 0.10.0-alpha
 
-- [Implement `std::error::Error::source` for error type](https://github.com/rust-bitcoin/rust-bech32/pull/72)
+This release introduces a new `primitives` module that is basically a new implementation of the
+whole crate. We also add a `segwit` module but we have not yet settled on the exact new API in
+`lib.rs`, hence the `alpha` release.
 
 # 0.9.1
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bech32"
-version = "0.9.1"
+version = "0.10.0-alpha"
 authors = ["Clark Moody", "Andrew Poelstra", "Tobin Harding", "The rust-bitcoin developers"]
 repository = "https://github.com/rust-bitcoin/rust-bech32"
 documentation = "https://docs.rs/bech32/"


### PR DESCRIPTION
In preparation for doing an `alpha` release of the new `primitives` crate bump the version to `0.10.0-alpha` and add a changelog entry.

Let's Go!