### PR TITLE
primitives: Inline public functions

### DIFF
--- a/src/primitives/checksum.rs
+++ b/src/primitives/checksum.rs
@@ -93,9 +93,11 @@ impl<Ck: Checksum> Default for Engine<Ck> {
 
 impl<Ck: Checksum> Engine<Ck> {
     /// Constructs a new checksum engine with no data input.
+    #[inline]
     pub fn new() -> Self { Engine { residue: Ck::MidstateRepr::ONE } }
 
     /// Feeds `hrp` into the checksum engine.
+    #[inline]
     pub fn input_hrp(&mut self, hrp: &Hrp) {
         for fe in HrpFe32Iter::new(hrp) {
             self.input_fe(fe)
@@ -105,6 +107,7 @@ impl<Ck: Checksum> Engine<Ck> {
     /// Adds a single gf32 element to the checksum engine.
     ///
     /// This is where the actual checksum computation magic happens.
+    #[inline]
     pub fn input_fe(&mut self, e: Fe32) {
         let xn = self.residue.mul_by_x_then_add(Ck::CHECKSUM_LENGTH, e.into());
         for i in 0..5 {
@@ -120,6 +123,7 @@ impl<Ck: Checksum> Engine<Ck> {
     /// string, then computing the actual residue, and then replacing the
     /// target with the actual. This method lets us compute the actual residue
     /// without doing any string concatenations.
+    #[inline]
     pub fn input_target_residue(&mut self) {
         for i in 0..Ck::CHECKSUM_LENGTH {
             self.input_fe(Fe32(Ck::TARGET_RESIDUE.unpack(Ck::CHECKSUM_LENGTH - i - 1)));
@@ -127,6 +131,7 @@ impl<Ck: Checksum> Engine<Ck> {
     }
 
     /// Returns for the current checksum residue.
+    #[inline]
     pub fn residue(&self) -> &Ck::MidstateRepr { &self.residue }
 }
 
@@ -161,12 +166,15 @@ pub struct PackedNull;
 
 impl ops::BitXor<PackedNull> for PackedNull {
     type Output = PackedNull;
+    #[inline]
     fn bitxor(self, _: PackedNull) -> PackedNull { PackedNull }
 }
 
 impl PackedFe32 for PackedNull {
     const ONE: Self = PackedNull;
+    #[inline]
     fn unpack(&self, _: usize) -> u8 { 0 }
+    #[inline]
     fn mul_by_x_then_add(&mut self, _: usize, _: u8) -> u8 { 0 }
 }
 
@@ -175,11 +183,13 @@ macro_rules! impl_packed_fe32 {
         impl PackedFe32 for $ty {
             const ONE: Self = 1;
 
+            #[inline]
             fn unpack(&self, n: usize) -> u8 {
                 debug_assert!(n < Self::WIDTH);
                 (*self >> (n * 5)) as u8 & 0x1f
             }
 
+            #[inline]
             fn mul_by_x_then_add(&mut self, degree: usize, add: u8) -> u8 {
                 debug_assert!(degree > 0);
                 debug_assert!(degree <= Self::WIDTH);
@@ -208,6 +218,7 @@ pub struct HrpFe32Iter<'hrp> {
 impl<'hrp> HrpFe32Iter<'hrp> {
     /// Creates an iterator that yields the field elements of `hrp` as they are input into the
     /// checksum algorithm.
+    #[inline]
     pub fn new(hrp: &'hrp Hrp) -> Self {
         let high_iter = hrp.lowercase_byte_iter();
         let low_iter = hrp.lowercase_byte_iter();
@@ -218,6 +229,7 @@ impl<'hrp> HrpFe32Iter<'hrp> {
 
 impl<'hrp> Iterator for HrpFe32Iter<'hrp> {
     type Item = Fe32;
+    #[inline]
     fn next(&mut self) -> Option<Fe32> {
         if let Some(ref mut high_iter) = &mut self.high_iter {
             match high_iter.next() {
@@ -237,6 +249,7 @@ impl<'hrp> Iterator for HrpFe32Iter<'hrp> {
         None
     }
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         let high = match &self.high_iter {
             Some(high_iter) => {

--- a/src/primitives/decode.rs
+++ b/src/primitives/decode.rs
@@ -122,6 +122,7 @@ impl<'s> UncheckedHrpstring<'s> {
     /// Parses an bech32 encode string and constructs a [`UncheckedHrpstring`] object.
     ///
     /// Checks for valid ASCII values, does not validate the checksum.
+    #[inline]
     pub fn new(s: &'s str) -> Result<Self, UncheckedHrpstringError> {
         let sep_pos = check_characters(s)?;
         let (hrp, data) = s.split_at(sep_pos);
@@ -135,9 +136,11 @@ impl<'s> UncheckedHrpstring<'s> {
     }
 
     /// Returns the human-readable part.
+    #[inline]
     pub fn hrp(&self) -> Hrp { self.hrp }
 
     /// Validates that data has a valid checksum for the `Ck` algorithm and returns a [`CheckedHrpstring`].
+    #[inline]
     pub fn validate_and_remove_checksum<Ck: Checksum>(
         self,
     ) -> Result<CheckedHrpstring<'s>, ChecksumError> {
@@ -151,12 +154,14 @@ impl<'s> UncheckedHrpstring<'s> {
     /// This is useful if you do not know which checksum algorithm was used and wish to validate
     /// against multiple algorithms consecutively. If this function returns `true` then call
     /// `remove_checksum` to get a [`CheckedHrpstring`].
+    #[inline]
     pub fn has_valid_checksum<Ck: Checksum>(&self) -> bool {
         self.validate_checksum::<Ck>().is_ok()
     }
 
     /// Validates that data has a valid checksum for the `Ck` algorithm (this may mean an empty
     /// checksum if `NoChecksum` is used).
+    #[inline]
     pub fn validate_checksum<Ck: Checksum>(&self) -> Result<(), ChecksumError> {
         use ChecksumError::*;
 
@@ -193,6 +198,7 @@ impl<'s> UncheckedHrpstring<'s> {
     /// # Panics
     ///
     /// May panic if data is not valid.
+    #[inline]
     pub fn remove_checksum<Ck: Checksum>(self) -> CheckedHrpstring<'s> {
         let data_len = self.data.len() - Ck::CHECKSUM_LENGTH;
 
@@ -237,6 +243,7 @@ impl<'s> CheckedHrpstring<'s> {
     /// If you are validating the checksum multiple times consider using [`UncheckedHrpstring`].
     ///
     /// This is equivalent to `UncheckedHrpstring::new().validate_and_remove_checksum::<CK>()`.
+    #[inline]
     pub fn new<Ck: Checksum>(s: &'s str) -> Result<Self, CheckedHrpstringError> {
         let unchecked = UncheckedHrpstring::new(s)?;
         let checked = unchecked.validate_and_remove_checksum::<Ck>()?;
@@ -244,17 +251,20 @@ impl<'s> CheckedHrpstring<'s> {
     }
 
     /// Returns the human-readable part.
+    #[inline]
     pub fn hrp(&self) -> Hrp { self.hrp }
 
     /// Returns an iterator that yields the data part of the parsed bech32 encoded string.
     ///
     /// Converts the ASCII bytes representing field elements to the respective field elements, then
     /// converts the stream of field elements to a stream of bytes.
+    #[inline]
     pub fn byte_iter(&self) -> ByteIter {
         ByteIter { iter: AsciiToFe32Iter { iter: self.data.iter().copied() }.fes_to_bytes() }
     }
 
     /// Converts this type to a [`SegwitHrpstring`] after validating the witness and HRP.
+    #[inline]
     pub fn validate_segwit(mut self) -> Result<SegwitHrpstring<'s>, SegwitHrpstringError> {
         if self.data.is_empty() {
             return Err(SegwitHrpstringError::MissingWitnessVersion);
@@ -362,6 +372,7 @@ impl<'s> SegwitHrpstring<'s> {
     ///
     /// NOTE: We do not enforce any restrictions on the HRP, use [`SegwitHrpstring::has_valid_hrp`]
     /// to get strict BIP conformance (also [`Hrp::is_valid_on_mainnet`] and friends).
+    #[inline]
     pub fn new(s: &'s str) -> Result<Self, SegwitHrpstringError> {
         let unchecked = UncheckedHrpstring::new(s)?;
 
@@ -391,6 +402,7 @@ impl<'s> SegwitHrpstring<'s> {
     ///
     /// [BIP-173]: https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki
     /// [BIP-350]: https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki
+    #[inline]
     pub fn new_bech32(s: &'s str) -> Result<Self, SegwitHrpstringError> {
         let unchecked = UncheckedHrpstring::new(s)?;
 
@@ -409,12 +421,15 @@ impl<'s> SegwitHrpstring<'s> {
     /// BIP-173 requires that the HRP is "bc" or "tb" but software in the Bitcoin ecosystem uses
     /// other HRPs, specifically "bcrt" for regtest addresses. We provide this function in order to
     /// be BIP-173 compliant but their are no restrictions on the HRP of [`SegwitHrpstring`].
+    #[inline]
     pub fn has_valid_hrp(&self) -> bool { self.hrp().is_valid_segwit() }
 
     /// Returns the human-readable part.
+    #[inline]
     pub fn hrp(&self) -> Hrp { self.hrp }
 
     /// Returns the witness version.
+    #[inline]
     pub fn witness_version(&self) -> Fe32 { self.witness_version }
 
     /// Returns an iterator that yields the data part, excluding the witness version, of the parsed
@@ -424,6 +439,7 @@ impl<'s> SegwitHrpstring<'s> {
     /// converts the stream of field elements to a stream of bytes.
     ///
     /// Use `self.witness_version()` to get the witness version.
+    #[inline]
     pub fn byte_iter(&self) -> ByteIter {
         ByteIter { iter: AsciiToFe32Iter { iter: self.data.iter().copied() }.fes_to_bytes() }
     }
@@ -472,11 +488,14 @@ pub struct ByteIter<'s> {
 
 impl<'s> Iterator for ByteIter<'s> {
     type Item = u8;
+    #[inline]
     fn next(&mut self) -> Option<u8> { self.iter.next() }
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) { self.iter.size_hint() }
 }
 
 impl<'s> ExactSizeIterator for ByteIter<'s> {
+    #[inline]
     fn len(&self) -> usize { self.iter.len() }
 }
 
@@ -487,7 +506,9 @@ pub struct Fe32Iter<'s> {
 
 impl<'s> Iterator for Fe32Iter<'s> {
     type Item = Fe32;
+    #[inline]
     fn next(&mut self) -> Option<Fe32> { self.iter.next() }
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) { self.iter.size_hint() }
 }
 
@@ -507,7 +528,9 @@ where
     I: Iterator<Item = u8>,
 {
     type Item = Fe32;
+    #[inline]
     fn next(&mut self) -> Option<Fe32> { self.iter.next().map(Fe32::from_char_unchecked) }
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         // Each ASCII character is an fe32 so iterators are the same size.
         self.iter.size_hint()
@@ -518,6 +541,7 @@ impl<I> ExactSizeIterator for AsciiToFe32Iter<I>
 where
     I: Iterator<Item = u8> + ExactSizeIterator,
 {
+    #[inline]
     fn len(&self) -> usize { self.iter.len() }
 }
 

--- a/src/primitives/encode.rs
+++ b/src/primitives/encode.rs
@@ -90,6 +90,7 @@ where
     Ck: Checksum,
 {
     /// Constructs a new bech32 encoder.
+    #[inline]
     pub fn new(data: I, hrp: &'hrp Hrp) -> Self {
         Self { data, hrp, witness_version: None, marker: PhantomData::<Ck> }
     }
@@ -97,12 +98,14 @@ where
     /// Adds `witness_version` to the encoder (as first byte of encoded data).
     ///
     /// Note, caller to guarantee that witness version is within valid range (0-16).
+    #[inline]
     pub fn with_witness_version(mut self, witness_version: Fe32) -> Self {
         self.witness_version = Some(witness_version);
         self
     }
 
     /// Returns an iterator that yields the bech32 encoded address as field ASCII characters.
+    #[inline]
     pub fn chars(self) -> CharIter<'hrp, I, Ck> {
         let witver_iter = WitnessVersionIter::new(self.witness_version, self.data);
         CharIter::new(self.hrp, witver_iter)
@@ -111,6 +114,7 @@ where
     /// Returns an iterator that yields the field elements that go into the checksum, as well as the checksum at the end.
     ///
     /// Each field element yielded has been input into the checksum algorithm (including the HRP as it is fed into the algorithm).
+    #[inline]
     pub fn fes(self) -> Fe32Iter<'hrp, I, Ck> {
         let witver_iter = WitnessVersionIter::new(self.witness_version, self.data);
         Fe32Iter::new(self.hrp, witver_iter)
@@ -133,6 +137,7 @@ where
     I: Iterator<Item = Fe32>,
 {
     /// Creates a [`WitnessVersionIter`].
+    #[inline]
     pub fn new(witness_version: Option<Fe32>, iter: I) -> Self { Self { witness_version, iter } }
 }
 
@@ -142,8 +147,10 @@ where
 {
     type Item = Fe32;
 
+    #[inline]
     fn next(&mut self) -> Option<Fe32> { self.witness_version.take().or_else(|| self.iter.next()) }
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         let (min, max) = self.iter.size_hint();
         match self.witness_version {
@@ -174,6 +181,7 @@ where
     Ck: Checksum,
 {
     /// Adapts the `Fe32Iter` iterator to yield characters representing the bech32 encoding.
+    #[inline]
     pub fn new(hrp: &'hrp Hrp, data: WitnessVersionIter<I>) -> Self {
         let checksummed = Checksummed::new_hrp(hrp, data);
         Self { hrp_iter: Some(hrp.lowercase_char_iter()), checksummed }
@@ -187,6 +195,7 @@ where
 {
     type Item = char;
 
+    #[inline]
     fn next(&mut self) -> Option<char> {
         if let Some(ref mut hrp_iter) = self.hrp_iter {
             match hrp_iter.next() {
@@ -201,6 +210,7 @@ where
         self.checksummed.next().map(|fe| fe.to_char())
     }
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         match &self.hrp_iter {
             // We have yielded the hrp and separator already.
@@ -245,6 +255,7 @@ where
     Ck: Checksum,
 {
     /// Creates a [`Fe32Iter`] which yields all the field elements which go into the checksum algorithm.
+    #[inline]
     pub fn new(hrp: &'hrp Hrp, data: WitnessVersionIter<I>) -> Self {
         let hrp_iter = HrpFe32Iter::new(hrp);
         let checksummed = Checksummed::new_hrp(hrp, data);
@@ -258,6 +269,7 @@ where
     Ck: Checksum,
 {
     type Item = Fe32;
+    #[inline]
     fn next(&mut self) -> Option<Fe32> {
         if let Some(ref mut hrp_iter) = &mut self.hrp_iter {
             match hrp_iter.next() {
@@ -268,6 +280,7 @@ where
         self.checksummed.next()
     }
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         let hrp = match &self.hrp_iter {
             Some(hrp_iter) => hrp_iter.size_hint(),

--- a/src/primitives/gf32.rs
+++ b/src/primitives/gf32.rs
@@ -135,6 +135,7 @@ impl Fe32 {
     pub const L: Fe32 = Fe32(31);
 
     /// Iterator over all field elements, in alphabetical order.
+    #[inline]
     pub fn iter_alpha() -> impl Iterator<Item = Fe32> {
         [
             Fe32::A,
@@ -175,6 +176,7 @@ impl Fe32 {
     }
 
     /// Creates a field element from a single bech32 character.
+    #[inline]
     pub fn from_char(c: char) -> Result<Fe32, Error> {
         // i8::try_from gets a value in the range 0..=127 since char is unsigned.
         let byte = i8::try_from(u32::from(c)).map_err(|_| Error::InvalidChar(c))?;
@@ -188,6 +190,7 @@ impl Fe32 {
     pub(crate) fn from_char_unchecked(c: u8) -> Fe32 { Fe32(CHARS_INV[usize::from(c)] as u8) }
 
     /// Converts the field element to a lowercase bech32 character.
+    #[inline]
     pub fn to_char(self) -> char {
         // Indexing fine as we have self.0 in [0, 32) as an invariant.
         CHARS_LOWER[usize::from(self.0)]
@@ -195,6 +198,7 @@ impl Fe32 {
 
     /// Converts the field element to a 5-bit u8, with bits representing the coefficients
     /// of the polynomial representation.
+    #[inline]
     pub fn to_u8(self) -> u8 { self.0 }
 
     fn _add(self, other: Fe32) -> Fe32 { Fe32(self.0 ^ other.0) }
@@ -232,6 +236,7 @@ impl fmt::Display for Fe32 {
 }
 
 impl From<Fe32> for u8 {
+    #[inline]
     fn from(v: Fe32) -> u8 { v.0 }
 }
 
@@ -246,6 +251,7 @@ macro_rules! impl_try_from {
                 /// # Errors
                 ///
                 /// Returns an error if `value` is outside of the range of an `Fe32`.
+                #[inline]
                 fn try_from(value: $ty) -> Result<Self, Self::Error> {
                     let byte = u8::try_from(value)?;
                     if byte > 31 {
@@ -260,6 +266,7 @@ macro_rules! impl_try_from {
 impl_try_from!(u8 u16 u32 u64 u128 i8 i16 i32 i64 i128);
 
 impl AsRef<u8> for Fe32 {
+    #[inline]
     fn as_ref(&self) -> &u8 { &self.0 }
 }
 
@@ -268,21 +275,25 @@ macro_rules! impl_op_matrix {
     ($op:ident, $op_fn:ident, $call_fn:ident) => {
         impl ops::$op<Fe32> for Fe32 {
             type Output = Fe32;
+            #[inline]
             fn $op_fn(self, other: Fe32) -> Fe32 { self.$call_fn(other) }
         }
 
         impl ops::$op<Fe32> for &Fe32 {
             type Output = Fe32;
+            #[inline]
             fn $op_fn(self, other: Fe32) -> Fe32 { self.$call_fn(other) }
         }
 
         impl ops::$op<&Fe32> for Fe32 {
             type Output = Fe32;
+            #[inline]
             fn $op_fn(self, other: &Fe32) -> Fe32 { self.$call_fn(*other) }
         }
 
         impl ops::$op<&Fe32> for &Fe32 {
             type Output = Fe32;
+            #[inline]
             fn $op_fn(self, other: &Fe32) -> Fe32 { self.$call_fn(*other) }
         }
     };
@@ -293,18 +304,22 @@ impl_op_matrix!(Mul, mul, _mul);
 impl_op_matrix!(Div, div, _div);
 
 impl ops::AddAssign for Fe32 {
+    #[inline]
     fn add_assign(&mut self, other: Fe32) { *self = *self + other; }
 }
 
 impl ops::SubAssign for Fe32 {
+    #[inline]
     fn sub_assign(&mut self, other: Fe32) { *self = *self - other; }
 }
 
 impl ops::MulAssign for Fe32 {
+    #[inline]
     fn mul_assign(&mut self, other: Fe32) { *self = *self * other; }
 }
 
 impl ops::DivAssign for Fe32 {
+    #[inline]
     fn div_assign(&mut self, other: Fe32) { *self = *self / other; }
 }
 

--- a/src/primitives/hrp.rs
+++ b/src/primitives/hrp.rs
@@ -63,6 +63,7 @@ impl Hrp {
     /// > specific applications.
     ///
     /// [BIP-173]: <https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki>
+    #[inline]
     pub fn parse(hrp: &str) -> Result<Self, Error> { Ok(Self::parse_and_case(hrp)?.0) }
 
     /// Parses the human-readable part (see [`Hrp::parse`] for full docs).
@@ -147,26 +148,31 @@ impl Hrp {
 
     /// Returns this human-readable part as a lowercase string.
     #[cfg(feature = "alloc")]
+    #[inline]
     pub fn to_lowercase(&self) -> String { self.lowercase_char_iter().collect() }
 
     /// Creates a byte iterator over the ASCII byte values (ASCII characters) of this HRP.
     ///
     /// If an uppercase HRP was parsed during object construction then this iterator will yield
     /// uppercase ASCII `char`s. For lowercase bytes see [`Self::lowercase_byte_iter`]
+    #[inline]
     pub fn byte_iter(&self) -> ByteIter { ByteIter { iter: self.buf[..self.size].iter() } }
 
     /// Creates a character iterator over the ASCII characters of this HRP.
     ///
     /// If an uppercase HRP was parsed during object construction then this iterator will yield
     /// uppercase ASCII `char`s. For lowercase bytes see [`Self::lowercase_char_iter`].
+    #[inline]
     pub fn char_iter(&self) -> CharIter { CharIter { iter: self.byte_iter() } }
 
     /// Creates a lowercase iterator over the byte values (ASCII characters) of this HRP.
+    #[inline]
     pub fn lowercase_byte_iter(&self) -> LowercaseByteIter {
         LowercaseByteIter { iter: self.byte_iter() }
     }
 
     /// Creates a lowercase character iterator over the ASCII characters of this HRP.
+    #[inline]
     pub fn lowercase_char_iter(&self) -> LowercaseCharIter {
         LowercaseCharIter { iter: self.lowercase_byte_iter() }
     }
@@ -174,9 +180,11 @@ impl Hrp {
     /// Returns the length (number of characters) of the human-readable part.
     ///
     /// Guaranteed to be between 1 and 83 inclusive.
+    #[inline]
     pub fn len(&self) -> usize { self.size }
 
     /// Always false, the human-readable part is guaranteed to be between 1-83 characters.
+    #[inline]
     pub fn is_empty(&self) -> bool { false }
 
     /// Returns `true` if this [`Hrp`] is valid according to the bips.
@@ -184,20 +192,25 @@ impl Hrp {
     /// [BIP-173] states that the HRP must be either "bc" or "tb".
     ///
     /// [BIP-173]: https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#user-content-Segwit_address_format
+    #[inline]
     pub fn is_valid_segwit(&self) -> bool {
         self.is_valid_on_mainnet() || self.is_valid_on_testnet()
     }
 
     /// Returns `true` if this hrpstring is valid on the Bitcoin network i.e., HRP is "bc".
+    #[inline]
     pub fn is_valid_on_mainnet(&self) -> bool { *self == self::BC }
 
     /// Returns `true` if this hrpstring is valid on the Bitcoin testnet network i.e., HRP is "tb".
+    #[inline]
     pub fn is_valid_on_testnet(&self) -> bool { *self == self::TB }
 
     /// Returns `true` if this hrpstring is valid on the Bitcoin signet network i.e., HRP is "tb".
+    #[inline]
     pub fn is_valid_on_signet(&self) -> bool { *self == self::TB }
 
     /// Returns `true` if this hrpstring is valid on the Bitcoin regtest network i.e., HRP is "bcrt".
+    #[inline]
     pub fn is_valid_on_regtest(&self) -> bool { *self == self::BC }
 }
 
@@ -216,6 +229,7 @@ impl fmt::Display for Hrp {
 
 /// Case insensitive comparison.
 impl Ord for Hrp {
+    #[inline]
     fn cmp(&self, other: &Self) -> Ordering {
         self.lowercase_byte_iter().cmp(other.lowercase_byte_iter())
     }
@@ -223,11 +237,13 @@ impl Ord for Hrp {
 
 /// Case insensitive comparison.
 impl PartialOrd for Hrp {
+    #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> { Some(self.cmp(other)) }
 }
 
 /// Case insensitive comparison.
 impl PartialEq for Hrp {
+    #[inline]
     fn eq(&self, other: &Self) -> bool {
         self.lowercase_byte_iter().eq(other.lowercase_byte_iter())
     }
@@ -236,6 +252,7 @@ impl PartialEq for Hrp {
 impl Eq for Hrp {}
 
 impl core::hash::Hash for Hrp {
+    #[inline]
     fn hash<H: core::hash::Hasher>(&self, h: &mut H) { self.buf.hash(h) }
 }
 
@@ -248,15 +265,19 @@ pub struct ByteIter<'b> {
 
 impl<'b> Iterator for ByteIter<'b> {
     type Item = u8;
+    #[inline]
     fn next(&mut self) -> Option<u8> { self.iter.next().copied() }
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) { self.iter.size_hint() }
 }
 
 impl<'b> ExactSizeIterator for ByteIter<'b> {
+    #[inline]
     fn len(&self) -> usize { self.iter.len() }
 }
 
 impl<'b> DoubleEndedIterator for ByteIter<'b> {
+    #[inline]
     fn next_back(&mut self) -> Option<Self::Item> { self.iter.next_back().copied() }
 }
 
@@ -271,15 +292,19 @@ pub struct CharIter<'b> {
 
 impl<'b> Iterator for CharIter<'b> {
     type Item = char;
+    #[inline]
     fn next(&mut self) -> Option<char> { self.iter.next().map(Into::into) }
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) { self.iter.size_hint() }
 }
 
 impl<'b> ExactSizeIterator for CharIter<'b> {
+    #[inline]
     fn len(&self) -> usize { self.iter.len() }
 }
 
 impl<'b> DoubleEndedIterator for CharIter<'b> {
+    #[inline]
     fn next_back(&mut self) -> Option<Self::Item> { self.iter.next_back().map(Into::into) }
 }
 
@@ -292,17 +317,21 @@ pub struct LowercaseByteIter<'b> {
 
 impl<'b> Iterator for LowercaseByteIter<'b> {
     type Item = u8;
+    #[inline]
     fn next(&mut self) -> Option<u8> {
         self.iter.next().map(|b| if is_ascii_uppercase(b) { b | 32 } else { b })
     }
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) { self.iter.size_hint() }
 }
 
 impl<'b> ExactSizeIterator for LowercaseByteIter<'b> {
+    #[inline]
     fn len(&self) -> usize { self.iter.len() }
 }
 
 impl<'b> DoubleEndedIterator for LowercaseByteIter<'b> {
+    #[inline]
     fn next_back(&mut self) -> Option<Self::Item> {
         self.iter.next_back().map(|b| if is_ascii_uppercase(b) { b | 32 } else { b })
     }
@@ -317,15 +346,19 @@ pub struct LowercaseCharIter<'b> {
 
 impl<'b> Iterator for LowercaseCharIter<'b> {
     type Item = char;
+    #[inline]
     fn next(&mut self) -> Option<char> { self.iter.next().map(Into::into) }
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) { self.iter.size_hint() }
 }
 
 impl<'b> ExactSizeIterator for LowercaseCharIter<'b> {
+    #[inline]
     fn len(&self) -> usize { self.iter.len() }
 }
 
 impl<'b> DoubleEndedIterator for LowercaseCharIter<'b> {
+    #[inline]
     fn next_back(&mut self) -> Option<Self::Item> { self.iter.next_back().map(Into::into) }
 }
 

--- a/src/primitives/iter.rs
+++ b/src/primitives/iter.rs
@@ -38,6 +38,7 @@ pub trait ByteIterExt: Sized + Iterator<Item = u8> {
     /// Adapts the byte iterator to output GF32 field elements instead.
     ///
     /// If the total number of bits is not a multiple of 5 we pad with 0s
+    #[inline]
     fn bytes_to_fes(mut self) -> BytesToFes<Self> {
         BytesToFes { last_byte: self.next(), bit_offset: 0, iter: self }
     }
@@ -51,11 +52,13 @@ pub trait Fe32IterExt: Sized + Iterator<Item = Fe32> {
     ///
     /// If the total number of bits is not a multiple of 8, any trailing bits
     /// are simply dropped.
+    #[inline]
     fn fes_to_bytes(mut self) -> FesToBytes<Self> {
         FesToBytes { last_fe: self.next(), bit_offset: 0, iter: self }
     }
 
     /// Adapts the Fe32 iterator to encode the field elements into a bech32 address.
+    #[inline]
     fn with_checksum<Ck: Checksum>(self, hrp: &Hrp) -> Encoder<Self, Ck> { Encoder::new(self, hrp) }
 }
 
@@ -77,6 +80,7 @@ where
 {
     type Item = Fe32;
 
+    #[inline]
     fn next(&mut self) -> Option<Fe32> {
         use core::cmp::Ordering::*;
 
@@ -104,6 +108,7 @@ where
         }
     }
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         let (min, max) = self.iter.size_hint();
         let (min, max) = match self.last_byte {
@@ -129,6 +134,7 @@ impl<I> ExactSizeIterator for BytesToFes<I>
 where
     I: Iterator<Item = u8> + ExactSizeIterator,
 {
+    #[inline]
     fn len(&self) -> usize {
         let len = match self.last_byte {
             Some(_) => self.iter.len() + 1,
@@ -188,6 +194,7 @@ where
         }
     }
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         // If the total number of bits is not a multiple of 8, any trailing bits are dropped.
         let fes_len_to_bytes_len = |n| n * 5 / 8;
@@ -207,6 +214,7 @@ impl<I> ExactSizeIterator for FesToBytes<I>
 where
     I: Iterator<Item = Fe32> + ExactSizeIterator,
 {
+    #[inline]
     fn len(&self) -> usize {
         let len = match self.last_fe {
             Some(_) => self.iter.len() + 1,
@@ -236,6 +244,7 @@ where
 {
     /// Creates a new checksummed iterator which adapts a data iterator of field elements by
     /// appending a checksum.
+    #[inline]
     pub fn new(data: I) -> Checksummed<I, Ck> {
         Checksummed {
             iter: data,
@@ -246,6 +255,7 @@ where
 
     /// Creates a new checksummed iterator which adapts a data iterator of field elements by
     /// first inputting the [`Hrp`] and then appending a checksum.
+    #[inline]
     pub fn new_hrp(hrp: &Hrp, data: I) -> Checksummed<I, Ck> {
         let mut ret = Self::new(data);
         ret.checksum_engine.input_hrp(hrp);
@@ -260,6 +270,7 @@ where
 {
     type Item = Fe32;
 
+    #[inline]
     fn next(&mut self) -> Option<Fe32> {
         match self.iter.next() {
             Some(fe) => {
@@ -279,6 +290,7 @@ where
         }
     }
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         let add = self.checksum_remaining;
         let (min, max) = self.iter.size_hint();


### PR DESCRIPTION
Audit the `primitives` module and all submodules; add inline to all public methods that are small enough (excl. error impls).