### PR TITLE
Add transparent representation for u5

### DIFF
--- a/src/primitives/gf32.rs
+++ b/src/primitives/gf32.rs
@@ -65,6 +65,7 @@ const CHARS_INV: [i8; 128] = [
 
 /// An element in GF(32), the finite field containing elements `[0,31]` inclusive.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[repr(transparent)]
 pub struct Fe32(pub(crate) u8);
 
 impl Fe32 {


### PR DESCRIPTION
As mentioned in https://github.com/rust-bitcoin/rust-bech32/issues/19 having transparent representation for u5 opens many optimization.

According to change log in Rust repo, this feature was [stabilized in 1.28](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1280-2018-08-02)