### PR TITLE
Remove mention of arrayvec from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Bitcoin-specific address encoding is handled by the `bitcoin-bech32` crate.
 
 ## MSRV
 
-This library should always compile with any combination of features excluding "arrayvec" on **Rust 1.48.0**.
+This library should always compile with any combination of features on **Rust 1.48.0**.
 
 
 ## Githooks


### PR DESCRIPTION
We no longer have an arrayvec feature, remove the mention of it from the readme.