### PR TITLE
Remove "the rust bitcoin developers" from manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bech32"
 version = "0.10.0-alpha"
-authors = ["Clark Moody", "Andrew Poelstra", "Tobin Harding", "The rust-bitcoin developers"]
+authors = ["Clark Moody", "Andrew Poelstra", "Tobin Harding"]
 repository = "https://github.com/rust-bitcoin/rust-bech32"
 documentation = "https://docs.rs/bech32/"
 description = "Encodes and decodes the Bech32 format and implements the bech32 and bech32m checksums"


### PR DESCRIPTION
We don't use this phrase much anymore, remove it.