### PR TITLE
Check the correct regtest HRP

### DIFF
--- a/src/primitives/hrp.rs
+++ b/src/primitives/hrp.rs
@@ -211,7 +211,7 @@ impl Hrp {
 
     /// Returns `true` if this hrpstring is valid on the Bitcoin regtest network i.e., HRP is "bcrt".
     #[inline]
-    pub fn is_valid_on_regtest(&self) -> bool { *self == self::BC }
+    pub fn is_valid_on_regtest(&self) -> bool { *self == self::BCRT }
 }
 
 /// Displays the human-readable part.


### PR DESCRIPTION
We currently check  the wrong `HRP` in `is_valid_on_regtest`, ouch.