### PR TITLE
Make `write_err` macro private

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -5,7 +5,6 @@
 /// If `std` feature is OFF appends error source (delimited by `: `). We do this because
 /// `e.source()` is only available in std builds, without this macro the error source is lost for
 /// no-std builds.
-#[macro_export]
 macro_rules! write_err {
     ($writer:expr, $string:literal $(, $args:expr)*; $source:expr) => {
         {
@@ -21,3 +20,4 @@ macro_rules! write_err {
         }
     }
 }
+pub(crate) use write_err;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ use alloc::{string::String, vec::Vec};
 use core::convert::{Infallible, TryFrom};
 use core::{fmt, mem};
 
+use crate::error::write_err;
 pub use crate::primitives::checksum::Checksum;
 use crate::primitives::checksum::{self, PackedFe32};
 pub use crate::primitives::gf32::Fe32;

--- a/src/primitives/decode.rs
+++ b/src/primitives/decode.rs
@@ -75,12 +75,13 @@
 
 use core::{fmt, iter, slice, str};
 
+use crate::error::write_err;
 use crate::primitives::checksum::{self, Checksum};
 use crate::primitives::gf32::Fe32;
 use crate::primitives::hrp::{self, Hrp};
 use crate::primitives::iter::{Fe32IterExt, FesToBytes};
 use crate::primitives::segwit::{self, WitnessLengthError, VERSION_0};
-use crate::{write_err, Bech32, Bech32m};
+use crate::{Bech32, Bech32m};
 
 /// Separator between the hrp and payload (as defined by BIP-173).
 const SEP: char = '1';

--- a/src/primitives/gf32.rs
+++ b/src/primitives/gf32.rs
@@ -16,7 +16,7 @@ use core::{fmt, num, ops};
 #[cfg(all(test, mutate))]
 use mutagen::mutate;
 
-use crate::write_err;
+use crate::error::write_err;
 
 /// Logarithm table of each bech32 element, as a power of alpha = Z.
 ///

--- a/src/segwit.rs
+++ b/src/segwit.rs
@@ -45,6 +45,7 @@
 use alloc::{string::String, vec::Vec};
 use core::fmt;
 
+use crate::error::write_err;
 #[cfg(feature = "alloc")]
 use crate::primitives::decode::{SegwitHrpstring, SegwitHrpstringError};
 use crate::primitives::gf32::Fe32;
@@ -53,7 +54,6 @@ use crate::primitives::iter::{ByteIterExt, Fe32IterExt};
 use crate::primitives::segwit::{self, InvalidWitnessVersionError, WitnessLengthError};
 pub use crate::primitives::segwit::{VERSION_0, VERSION_1};
 use crate::primitives::{Bech32, Bech32m};
-use crate::write_err;
 
 /// Decodes a segwit address.
 ///


### PR DESCRIPTION
Currently the `write_err` macro appears in the public API, there is no real benefit in this, its just one more thing to commit to post v1.0.0

Make the `write_err` macro private.