### PR TITLE
Audit error types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -345,7 +345,8 @@ pub fn encode_upper_to_writer<Ck: Checksum, W: std::io::Write>(
 
 /// An error while decoding an address.
 #[cfg(feature = "alloc")]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum DecodeError {
     /// Parsing failed.
     Parse(UncheckedHrpstringError),
@@ -379,12 +380,14 @@ impl std::error::Error for DecodeError {
 
 #[cfg(feature = "alloc")]
 impl From<UncheckedHrpstringError> for DecodeError {
+    #[inline]
     fn from(e: UncheckedHrpstringError) -> Self { Self::Parse(e) }
 }
 
 /// An error while decoding an address from a reader.
 #[cfg(feature = "std")]
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum DecodeFromReaderError {
     /// Read error.
     Read(std::io::Error),
@@ -418,11 +421,13 @@ impl std::error::Error for DecodeFromReaderError {
 
 #[cfg(feature = "std")]
 impl From<std::io::Error> for DecodeFromReaderError {
+    #[inline]
     fn from(e: std::io::Error) -> Self { Self::Read(e) }
 }
 
 #[cfg(feature = "std")]
 impl From<DecodeError> for DecodeFromReaderError {
+    #[inline]
     fn from(e: DecodeError) -> Self { Self::Decode(e) }
 }
 

--- a/src/primitives/decode.rs
+++ b/src/primitives/decode.rs
@@ -545,6 +545,7 @@ where
 
 /// An error while constructing a [`SegwitHrpstring`] type.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum SegwitHrpstringError {
     /// Error while parsing the encoded address string.
     Unchecked(UncheckedHrpstringError),
@@ -591,23 +592,28 @@ impl std::error::Error for SegwitHrpstringError {
 }
 
 impl From<UncheckedHrpstringError> for SegwitHrpstringError {
+    #[inline]
     fn from(e: UncheckedHrpstringError) -> Self { Self::Unchecked(e) }
 }
 
 impl From<WitnessLengthError> for SegwitHrpstringError {
+    #[inline]
     fn from(e: WitnessLengthError) -> Self { Self::WitnessLength(e) }
 }
 
 impl From<PaddingError> for SegwitHrpstringError {
+    #[inline]
     fn from(e: PaddingError) -> Self { Self::Padding(e) }
 }
 
 impl From<ChecksumError> for SegwitHrpstringError {
+    #[inline]
     fn from(e: ChecksumError) -> Self { Self::Checksum(e) }
 }
 
 /// An error while constructing a [`CheckedHrpstring`] type.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum CheckedHrpstringError {
     /// Error while parsing the encoded address string.
     Parse(UncheckedHrpstringError),
@@ -639,10 +645,12 @@ impl std::error::Error for CheckedHrpstringError {
 }
 
 impl From<UncheckedHrpstringError> for CheckedHrpstringError {
+    #[inline]
     fn from(e: UncheckedHrpstringError) -> Self { Self::Parse(e) }
 }
 
 impl From<ChecksumError> for CheckedHrpstringError {
+    #[inline]
     fn from(e: ChecksumError) -> Self { Self::Checksum(e) }
 }
 
@@ -680,10 +688,12 @@ impl std::error::Error for UncheckedHrpstringError {
 }
 
 impl From<CharError> for UncheckedHrpstringError {
+    #[inline]
     fn from(e: CharError) -> Self { Self::Char(e) }
 }
 
 impl From<hrp::Error> for UncheckedHrpstringError {
+    #[inline]
     fn from(e: hrp::Error) -> Self { Self::Hrp(e) }
 }
 
@@ -770,6 +780,7 @@ impl std::error::Error for ChecksumError {
 
 /// Error validating the padding bits on the witness data.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum PaddingError {
     /// The data payload has too many bits of padding.
     TooMuch,

--- a/src/primitives/gf32.rs
+++ b/src/primitives/gf32.rs
@@ -361,10 +361,12 @@ impl std::error::Error for Error {
 }
 
 impl From<num::TryFromIntError> for Error {
+    #[inline]
     fn from(e: num::TryFromIntError) -> Self { Error::NotAByte(e) }
 }
 
 impl From<Infallible> for Error {
+    #[inline]
     fn from(i: Infallible) -> Self { match i {} }
 }
 

--- a/src/primitives/segwit.rs
+++ b/src/primitives/segwit.rs
@@ -53,7 +53,8 @@ pub fn validate_witness_program_length(
 }
 
 /// Field element does not represent a valid witness version.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct InvalidWitnessVersionError(Fe32);
 
 impl fmt::Display for InvalidWitnessVersionError {
@@ -68,7 +69,7 @@ impl std::error::Error for InvalidWitnessVersionError {
 }
 
 /// Witness program invalid because of incorrect length.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum WitnessLengthError {
     /// The witness data is too short.

--- a/src/segwit.rs
+++ b/src/segwit.rs
@@ -263,6 +263,7 @@ pub fn encode_upper_to_writer_unchecked<W: std::io::Write>(
 /// An error while decoding a segwit address.
 #[cfg(feature = "alloc")]
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct DecodeError(pub SegwitHrpstringError);
 
 #[cfg(feature = "alloc")]
@@ -279,12 +280,14 @@ impl std::error::Error for DecodeError {
 
 #[cfg(feature = "alloc")]
 impl From<SegwitHrpstringError> for DecodeError {
+    #[inline]
     fn from(e: SegwitHrpstringError) -> Self { Self(e) }
 }
 
 /// An error while decoding a segwit address from a reader.
 #[cfg(feature = "std")]
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum DecodeFromReaderError {
     /// Read error.
     Read(std::io::Error),
@@ -318,16 +321,19 @@ impl std::error::Error for DecodeFromReaderError {
 
 #[cfg(feature = "std")]
 impl From<std::io::Error> for DecodeFromReaderError {
+    #[inline]
     fn from(e: std::io::Error) -> Self { Self::Read(e) }
 }
 
 #[cfg(feature = "std")]
 impl From<DecodeError> for DecodeFromReaderError {
+    #[inline]
     fn from(e: DecodeError) -> Self { Self::Decode(e) }
 }
 
 /// An error while constructing a [`SegwitHrpstring`] type.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum EncodeError {
     /// Invalid witness version (must be 0-16 inclusive).
     WitnessVersion(InvalidWitnessVersionError),
@@ -363,14 +369,17 @@ impl std::error::Error for EncodeError {
 }
 
 impl From<InvalidWitnessVersionError> for EncodeError {
+    #[inline]
     fn from(e: InvalidWitnessVersionError) -> Self { Self::WitnessVersion(e) }
 }
 
 impl From<WitnessLengthError> for EncodeError {
+    #[inline]
     fn from(e: WitnessLengthError) -> Self { Self::WitnessLength(e) }
 }
 
 impl From<fmt::Error> for EncodeError {
+    #[inline]
     fn from(e: fmt::Error) -> Self { Self::Write(e) }
 }
 


### PR DESCRIPTION
Audit all error types and ensure the following holds:

- All use `non_exhaustive`
- All derive `Debug, Clone, PartialEq, Eq` (unless `io::Error` is present, in which case only `Debug`)
- All error `From` impls use `inline`

This is similar to https://github.com/rust-bitcoin/rust-bitcoin/pull/2101, probably should have done this one first.