### PR TITLE
Bump version to 0.10.0-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.10.0-beta
+
+Re-implement the crate level API using the new `primitives` module.
+
 # 0.10.0-alpha
 
 This release introduces a new `primitives` module that is basically a new implementation of the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bech32"
-version = "0.10.0-alpha"
+version = "0.10.0-beta"
 authors = ["Clark Moody", "Andrew Poelstra", "Tobin Harding"]
 repository = "https://github.com/rust-bitcoin/rust-bech32"
 documentation = "https://docs.rs/bech32/"


### PR DESCRIPTION
In preparation for doing the next dev release add a changelog entry and bump the version number to `0.10.0-beta`.

We need to release the bug fix in #130 because fuzzing is hitting it in `rust-bitcoin`. This release would be better to use in `rust-miniscript` as well gearing up for the real 0.10.0 release.