### PR TITLE
Reduce line count by merging re-exports

### DIFF
--- a/src/hrp.rs
+++ b/src/hrp.rs
@@ -1,10 +1,4 @@
 // SPDX-License-Identifier: MIT
 
 #[doc(inline)]
-pub use crate::primitives::hrp::Hrp;
-#[doc(inline)]
-pub use crate::primitives::hrp::BC;
-#[doc(inline)]
-pub use crate::primitives::hrp::BCRT;
-#[doc(inline)]
-pub use crate::primitives::hrp::TB;
+pub use crate::primitives::hrp::{Hrp, BC, BCRT, TB};


### PR DESCRIPTION
Reduce line count and attribute usage by merging the `hrp` re-exports into a single statement.

Refactor only, no logic changes. Also, this patch does not introduce any changes to the rendered HTML.