### PR TITLE
Improve public re-exports

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,28 +130,6 @@ extern crate alloc;
 #[cfg(any(test, feature = "std"))]
 extern crate core;
 
-#[cfg(all(feature = "alloc", not(feature = "std"), not(test)))]
-use alloc::{string::String, vec::Vec};
-use core::fmt;
-
-use crate::error::write_err;
-#[doc(inline)]
-pub use crate::primitives::checksum::Checksum;
-#[cfg(doc)]
-use crate::primitives::decode::CheckedHrpstring;
-#[cfg(feature = "alloc")]
-use crate::primitives::decode::UncheckedHrpstringError;
-#[cfg(feature = "alloc")]
-use crate::primitives::decode::{ChecksumError, UncheckedHrpstring};
-#[doc(inline)]
-pub use crate::primitives::gf32::Fe32;
-#[doc(inline)]
-pub use crate::primitives::hrp::Hrp;
-#[doc(inline)]
-pub use crate::primitives::iter::{ByteIterExt, Fe32IterExt};
-#[doc(inline)]
-pub use crate::primitives::{Bech32, Bech32m, NoChecksum};
-
 mod error;
 /// Re-exports the hrp types from [`primitives::hrp`] to make importing ergonomic for the top level APIs.
 pub mod hrp;
@@ -159,6 +137,28 @@ pub mod hrp;
 pub mod primitives;
 /// API for encoding and decoding segwit addresses.
 pub mod segwit;
+
+#[cfg(all(feature = "alloc", not(feature = "std"), not(test)))]
+use alloc::{string::String, vec::Vec};
+use core::fmt;
+
+use crate::error::write_err;
+#[cfg(doc)]
+use crate::primitives::decode::CheckedHrpstring;
+#[cfg(feature = "alloc")]
+use crate::primitives::decode::UncheckedHrpstringError;
+#[cfg(feature = "alloc")]
+use crate::primitives::decode::{ChecksumError, UncheckedHrpstring};
+
+#[rustfmt::skip]                // Keep public re-exports separate.
+#[doc(inline)]
+pub use {
+    crate::primitives::checksum::Checksum,
+    crate::primitives::gf32::Fe32,
+    crate::primitives::hrp::Hrp,
+    crate::primitives::iter::{ByteIterExt, Fe32IterExt},
+    crate::primitives::{Bech32, Bech32m, NoChecksum},
+};
 
 /// Decodes a bech32 encoded string.
 ///

--- a/src/segwit.rs
+++ b/src/segwit.rs
@@ -53,9 +53,13 @@ use crate::primitives::iter::{ByteIterExt, Fe32IterExt};
 #[cfg(feature = "alloc")]
 use crate::primitives::segwit;
 use crate::primitives::segwit::{InvalidWitnessVersionError, WitnessLengthError};
-#[doc(inline)]
-pub use crate::primitives::segwit::{VERSION_0, VERSION_1};
 use crate::primitives::{Bech32, Bech32m};
+
+#[rustfmt::skip]                // Keep public re-exports separate.
+#[doc(inline)]
+pub use {
+    crate::primitives::segwit::{VERSION_0, VERSION_1},
+};
 
 /// Decodes a segwit address.
 ///


### PR DESCRIPTION
Improve the public exports in two ways:
    
1. Inline re-exports into the docs of the module that re-exports them.
2. Separate public and private use statements

Recently we discussed a way to separate the public and private import statements to make the code more clear and prevent `rustfmt` joining them all together.

Separate public exports using a code block and `#[rustfmt::skip]`. Has the nice advantage of reducing the number of `#[doc(inline)]` attributes also.

1. Modules first, as they are part of the project's structure.
2. Private imports
3. Public re-exports (using `rustfmt::skip` to prevent merge)

Use the format

```rust
mod xyz;
mod abc;

use ...;

pub use {
    ...,
};
```

This patch introduces changes to the rendered HTML docs.