### PR TITLE
Add buffering during encode

### DIFF
--- a/src/primitives/encode.rs
+++ b/src/primitives/encode.rs
@@ -113,6 +113,14 @@ where
         CharIter::new(self.hrp, witver_iter)
     }
 
+    /// Returns an iterator that yields the bech32 encoded address as field ASCII characters, as
+    /// byte values.
+    #[inline]
+    pub fn bytes(self) -> ByteIter<'hrp, I, Ck> {
+        let char_iter = self.chars();
+        ByteIter::new(char_iter)
+    }
+
     /// Returns an iterator that yields the field elements that go into the checksum, as well as the checksum at the end.
     ///
     /// Each field element yielded has been input into the checksum algorithm (including the HRP as it is fed into the algorithm).
@@ -237,6 +245,43 @@ where
     }
 }
 
+/// Iterator adaptor which takes a stream of ASCII field elements (an encoded string) and yields a stream of bytes.
+///
+/// This is equivalent to using the `CharsIter` and the casting each character to a byte. Doing
+/// so is technically sound because we only yield ASCII characters but it makes for ugly code so
+/// we provide this iterator also.
+pub struct ByteIter<'hrp, I, Ck>
+where
+    I: Iterator<Item = Fe32>,
+    Ck: Checksum,
+{
+    char_iter: CharIter<'hrp, I, Ck>,
+}
+
+impl<'hrp, I, Ck> ByteIter<'hrp, I, Ck>
+where
+    I: Iterator<Item = Fe32>,
+    Ck: Checksum,
+{
+    /// Adapts the `CharIter` iterator to yield bytes representing the bech32 encoding as ASCII bytes.
+    #[inline]
+    pub fn new(char_iter: CharIter<'hrp, I, Ck>) -> Self { Self { char_iter } }
+}
+
+impl<'a, I, Ck> Iterator for ByteIter<'a, I, Ck>
+where
+    I: Iterator<Item = Fe32>,
+    Ck: Checksum,
+{
+    type Item = u8;
+
+    #[inline]
+    fn next(&mut self) -> Option<u8> { self.char_iter.next().map(|c| c as u8) }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) { self.char_iter.size_hint() }
+}
+
 /// Iterator adaptor for a checksummed iterator that inputs the HRP into the checksum algorithm
 /// before yielding the HRP as field elements followed by the data then checksum.
 pub struct Fe32Iter<'hrp, I, Ck>
@@ -343,5 +388,20 @@ mod tests {
 
         let checksummed_len = 2 + 1 + 1 + char_len + 6; // bc + SEP + Q + chars + checksum
         assert_eq!(iter.size_hint().0, checksummed_len);
+    }
+
+    #[test]
+    #[cfg(feature = "alloc")]
+    fn hrpstring_iter_bytes() {
+        let hrp = Hrp::parse_unchecked("bc");
+        let fes = DATA.iter().copied().bytes_to_fes();
+        let iter = fes.with_checksum::<Bech32>(&hrp).with_witness_version(Fe32::Q);
+
+        let chars = iter.clone().chars();
+        let bytes = iter.bytes();
+
+        for (c, b) in chars.zip(bytes) {
+            assert_eq!(c as u8, b)
+        }
     }
 }

--- a/src/segwit.rs
+++ b/src/segwit.rs
@@ -156,19 +156,30 @@ pub fn encode_lower_to_fmt_unchecked<W: fmt::Write>(
     witness_version: Fe32,
     witness_program: &[u8],
 ) -> fmt::Result {
+    let mut buf = [0u8; MAX_STRING_LENGTH];
+    let mut pos = 0;
+
     let iter = witness_program.iter().copied().bytes_to_fes();
     match witness_version {
         VERSION_0 => {
-            for c in iter.with_checksum::<Bech32>(&hrp).with_witness_version(VERSION_0).chars() {
-                fmt.write_char(c)?;
-            }
+            let bytes = iter.with_checksum::<Bech32>(&hrp).with_witness_version(VERSION_0).bytes();
+            buf.iter_mut().zip(bytes).for_each(|(dst, src)| {
+                *dst = src;
+                pos += 1;
+            });
         }
         version => {
-            for c in iter.with_checksum::<Bech32m>(&hrp).with_witness_version(version).chars() {
-                fmt.write_char(c)?;
-            }
+            let bytes = iter.with_checksum::<Bech32m>(&hrp).with_witness_version(version).bytes();
+            buf.iter_mut().zip(bytes).for_each(|(dst, src)| {
+                *dst = src;
+                pos += 1;
+            });
         }
     }
+
+    let s = core::str::from_utf8(&buf[..pos]).expect("we only write ASCII");
+    fmt.write_str(s)?;
+
     Ok(())
 }
 
@@ -185,19 +196,29 @@ pub fn encode_upper_to_fmt_unchecked<W: fmt::Write>(
     witness_version: Fe32,
     witness_program: &[u8],
 ) -> fmt::Result {
+    let mut buf = [0u8; MAX_STRING_LENGTH];
+    let mut pos = 0;
+
     let iter = witness_program.iter().copied().bytes_to_fes();
     match witness_version {
         VERSION_0 => {
-            for c in iter.with_checksum::<Bech32>(&hrp).with_witness_version(VERSION_0).chars() {
-                fmt.write_char(c.to_ascii_uppercase())?;
-            }
+            let bytes = iter.with_checksum::<Bech32>(&hrp).with_witness_version(VERSION_0).bytes();
+            buf.iter_mut().zip(bytes).for_each(|(dst, src)| {
+                *dst = src.to_ascii_uppercase();
+                pos += 1;
+            });
         }
         version => {
-            for c in iter.with_checksum::<Bech32m>(&hrp).with_witness_version(version).chars() {
-                fmt.write_char(c.to_ascii_uppercase())?;
-            }
+            let bytes = iter.with_checksum::<Bech32m>(&hrp).with_witness_version(version).bytes();
+            buf.iter_mut().zip(bytes).for_each(|(dst, src)| {
+                *dst = src.to_ascii_uppercase();
+                pos += 1;
+            });
         }
     }
+
+    let s = core::str::from_utf8(&buf[..pos]).expect("we only write ASCII");
+    fmt.write_str(s)?;
 
     Ok(())
 }
@@ -229,19 +250,29 @@ pub fn encode_lower_to_writer_unchecked<W: std::io::Write>(
     witness_version: Fe32,
     witness_program: &[u8],
 ) -> std::io::Result<()> {
+    let mut buf = [0u8; MAX_STRING_LENGTH];
+    let mut pos = 0;
+
     let iter = witness_program.iter().copied().bytes_to_fes();
     match witness_version {
         VERSION_0 => {
-            for c in iter.with_checksum::<Bech32>(&hrp).with_witness_version(VERSION_0).chars() {
-                w.write_all(&[c.to_ascii_lowercase() as u8])?;
-            }
+            let bytes = iter.with_checksum::<Bech32>(&hrp).with_witness_version(VERSION_0).bytes();
+            buf.iter_mut().zip(bytes).for_each(|(dst, src)| {
+                *dst = src;
+                pos += 1;
+            });
         }
         version => {
-            for c in iter.with_checksum::<Bech32m>(&hrp).with_witness_version(version).chars() {
-                w.write_all(&[c.to_ascii_lowercase() as u8])?;
-            }
+            let bytes = iter.with_checksum::<Bech32m>(&hrp).with_witness_version(version).bytes();
+            buf.iter_mut().zip(bytes).for_each(|(dst, src)| {
+                *dst = src;
+                pos += 1;
+            });
         }
     }
+
+    w.write_all(&buf[..pos])?;
+
     Ok(())
 }
 
@@ -259,19 +290,28 @@ pub fn encode_upper_to_writer_unchecked<W: std::io::Write>(
     witness_version: Fe32,
     witness_program: &[u8],
 ) -> std::io::Result<()> {
+    let mut buf = [0u8; MAX_STRING_LENGTH];
+    let mut pos = 0;
+
     let iter = witness_program.iter().copied().bytes_to_fes();
     match witness_version {
         VERSION_0 => {
-            for c in iter.with_checksum::<Bech32>(&hrp).with_witness_version(VERSION_0).chars() {
-                w.write_all(&[c.to_ascii_uppercase() as u8])?;
-            }
+            let bytes = iter.with_checksum::<Bech32>(&hrp).with_witness_version(VERSION_0).bytes();
+            buf.iter_mut().zip(bytes).for_each(|(dst, src)| {
+                *dst = src.to_ascii_uppercase();
+                pos += 1;
+            });
         }
         version => {
-            for c in iter.with_checksum::<Bech32m>(&hrp).with_witness_version(version).chars() {
-                w.write_all(&[c.to_ascii_uppercase() as u8])?;
-            }
+            let bytes = iter.with_checksum::<Bech32m>(&hrp).with_witness_version(version).bytes();
+            buf.iter_mut().zip(bytes).for_each(|(dst, src)| {
+                *dst = src.to_ascii_uppercase();
+                pos += 1;
+            });
         }
     }
+
+    w.write_all(&buf[..pos])?;
 
     Ok(())
 }


### PR DESCRIPTION
Currently we write char at a time to both writers (`fmt::Write` and `std::io::Write`). We can improve performance by first collecting the ASCII bytes of the encoded bech32 string into a buffer on the stack then writing the buffer as a single call.
    
This is purely an optimization.

The second patch is surprising, at least to me, would love to learn what I'm doing wrong. I thought this would be valid
```rust
let mut buf = [0_u8; Ck::CODE_LENGTH]
```

But the compiler does not like the usage of an associated const.