### PR TITLE
Feature guard write_err import

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,6 +142,7 @@ pub mod segwit;
 use alloc::{string::String, vec::Vec};
 use core::fmt;
 
+#[cfg(feature = "alloc")]
 use crate::error::write_err;
 #[cfg(doc)]
 use crate::primitives::decode::CheckedHrpstring;


### PR DESCRIPTION
We only use the `write_err` macro when the "alloc" feature is enabled, the import statement should be feature guarded.

Clears a clippy warning.