### PR TITLE
Fix checksum error type

### DIFF
--- a/tests/bip_173_test_vectors.rs
+++ b/tests/bip_173_test_vectors.rs
@@ -18,12 +18,12 @@ fn bip_173_checksum_calculated_with_uppercase_form() {
 
     assert_eq!(
         CheckedHrpstring::new::<Bech32>(s).unwrap_err(),
-        CheckedHrpstringError::Checksum(ChecksumError::InvalidChecksum)
+        CheckedHrpstringError::Checksum(ChecksumError::InvalidResidue)
     );
 
     assert_eq!(
         SegwitHrpstring::new(s).unwrap_err(),
-        SegwitHrpstringError::Checksum(ChecksumError::InvalidChecksum)
+        SegwitHrpstringError::Checksum(ChecksumError::InvalidResidue)
     );
 }
 
@@ -35,7 +35,7 @@ macro_rules! check_valid_bech32 {
                 let p = UncheckedHrpstring::new($valid_bech32).unwrap();
                 p.validate_checksum::<Bech32>().expect("valid bech32");
                 // Valid bech32 strings are by definition invalid bech32m.
-                assert_eq!(p.validate_checksum::<Bech32m>().unwrap_err(), ChecksumError::InvalidChecksum);
+                assert_eq!(p.validate_checksum::<Bech32m>().unwrap_err(), ChecksumError::InvalidResidue);
             }
         )*
     }

--- a/tests/bip_350_test_vectors.rs
+++ b/tests/bip_350_test_vectors.rs
@@ -17,12 +17,12 @@ fn bip_350_checksum_calculated_with_uppercase_form() {
 
     assert_eq!(
         CheckedHrpstring::new::<Bech32m>(s).unwrap_err(),
-        CheckedHrpstringError::Checksum(ChecksumError::InvalidChecksum)
+        CheckedHrpstringError::Checksum(ChecksumError::InvalidResidue)
     );
 
     assert_eq!(
         SegwitHrpstring::new(s).unwrap_err(),
-        SegwitHrpstringError::Checksum(ChecksumError::InvalidChecksum)
+        SegwitHrpstringError::Checksum(ChecksumError::InvalidResidue)
     );
 }
 
@@ -34,7 +34,7 @@ macro_rules! check_valid_bech32m {
                 let p = UncheckedHrpstring::new($valid_bech32m).unwrap();
                 p.validate_checksum::<Bech32m>().expect("valid bech32m");
                 // Valid bech32m strings are by definition invalid bech32.
-                assert_eq!(p.validate_checksum::<Bech32>().unwrap_err(), ChecksumError::InvalidChecksum);
+                assert_eq!(p.validate_checksum::<Bech32>().unwrap_err(), ChecksumError::InvalidResidue);
             }
         )*
     }


### PR DESCRIPTION
We have a couple of checksum error problems;

- Unused checksum related variants in `CharError`
- Unuseful error message (duplicated string "invalid checksum")

Fix both at the same time by removing the unused variants from `CharError` and by renaming the `InvalidChecksum` variant to `InvalidResidue` and improving the `Display` impl appropriately.