### PR TITLE
Add a returns section to the docs on segwit::decode

### DIFF
--- a/src/segwit.rs
+++ b/src/segwit.rs
@@ -66,6 +66,10 @@ pub use {
 
 /// Decodes a segwit address.
 ///
+/// # Returns
+///
+/// The HRP, the witness version, and a guaranteed valid length witness program.
+///
 /// # Examples
 ///
 /// ```


### PR DESCRIPTION
We return a 3 element tuple but do not document what it is or the guarntees on the vector length. Do so.