### PR TITLE
Improve error display for invalid witness version

### DIFF
--- a/src/primitives/decode.rs
+++ b/src/primitives/decode.rs
@@ -589,6 +589,7 @@ pub enum SegwitHrpstringError {
     Checksum(ChecksumError),
 }
 
+#[rustfmt::skip]
 impl fmt::Display for SegwitHrpstringError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use SegwitHrpstringError::*;
@@ -596,12 +597,8 @@ impl fmt::Display for SegwitHrpstringError {
         match *self {
             Unchecked(ref e) => write_err!(f, "parsing unchecked hrpstring failed"; e),
             NoData => write!(f, "no data found after removing the checksum"),
-            TooLong(len) => write!(
-                f,
-                "encoded length {} exceeds spec limit {} chars",
-                len,
-                segwit::MAX_STRING_LENGTH
-            ),
+            TooLong(len) =>
+                write!(f, "encoded length {} exceeds spec limit {} chars", len, segwit::MAX_STRING_LENGTH),
             InvalidWitnessVersion(fe) => write!(f, "invalid segwit witness version: {}", fe),
             Padding(ref e) => write_err!(f, "invalid padding on the witness data"; e),
             WitnessLength(ref e) => write_err!(f, "invalid witness length"; e),

--- a/src/primitives/decode.rs
+++ b/src/primitives/decode.rs
@@ -599,7 +599,8 @@ impl fmt::Display for SegwitHrpstringError {
             NoData => write!(f, "no data found after removing the checksum"),
             TooLong(len) =>
                 write!(f, "encoded length {} exceeds spec limit {} chars", len, segwit::MAX_STRING_LENGTH),
-            InvalidWitnessVersion(fe) => write!(f, "invalid segwit witness version: {}", fe),
+            InvalidWitnessVersion(fe) =>
+                write!(f, "invalid segwit witness version: {} (bech32 character: '{}')", fe.to_u8(), fe),
             Padding(ref e) => write_err!(f, "invalid padding on the witness data"; e),
             WitnessLength(ref e) => write_err!(f, "invalid witness length"; e),
             Checksum(ref e) => write_err!(f, "invalid checksum"; e),

--- a/src/primitives/segwit.rs
+++ b/src/primitives/segwit.rs
@@ -65,9 +65,10 @@ pub fn validate_witness_program_length(
 #[non_exhaustive]
 pub struct InvalidWitnessVersionError(pub Fe32);
 
+#[rustfmt::skip]
 impl fmt::Display for InvalidWitnessVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "field element does not represent a valid witness version")
+        write!(f, "invalid segwit witness version: {} (bech32 character: '{}')", self.0.to_u8(), self.0)
     }
 }
 


### PR DESCRIPTION
We have two errors that cover invalid witness version, for one we print the field element which can be confusing for some values and for the other we omit the invalid version all together - we can do better.

Print the field element as well as the integer value when displaying the two invalid witness version errors.

Fix: #162