### PR TITLE
decode: Add accessors

### DIFF
--- a/src/primitives/decode.rs
+++ b/src/primitives/decode.rs
@@ -145,6 +145,25 @@ impl<'s> UncheckedHrpstring<'s> {
     #[inline]
     pub fn hrp(&self) -> Hrp { self.hrp }
 
+    /// Returns the data part as ASCII bytes i.e., everything after the separator '1'.
+    ///
+    /// The byte values are guaranteed to be valid bech32 characters. Includes the checksum
+    /// if one was present in the parsed string.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bech32::primitives::decode::UncheckedHrpstring;
+    ///
+    /// let addr = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq";
+    /// let ascii = "qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq";
+    ///
+    /// let unchecked = UncheckedHrpstring::new(&addr).unwrap();
+    /// assert!(unchecked.data_part_ascii().iter().eq(ascii.as_bytes().iter()))
+    /// ```
+    #[inline]
+    pub fn data_part_ascii(&self) -> &[u8] { self.data_part_ascii }
+
     /// Validates that data has a valid checksum for the `Ck` algorithm and returns a [`CheckedHrpstring`].
     #[inline]
     pub fn validate_and_remove_checksum<Ck: Checksum>(
@@ -275,6 +294,25 @@ impl<'s> CheckedHrpstring<'s> {
     #[inline]
     pub fn hrp(&self) -> Hrp { self.hrp }
 
+    /// Returns a partial slice of the data part, as ASCII bytes, everything after the separator '1'
+    /// before the checksum.
+    ///
+    /// The byte values are guaranteed to be valid bech32 characters.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bech32::{Bech32, primitives::decode::CheckedHrpstring};
+    ///
+    /// let addr = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq";
+    /// let ascii = "qar0srrr7xfkvy5l643lydnw9re59gtzz";
+    ///
+    /// let checked = CheckedHrpstring::new::<Bech32>(&addr).unwrap();
+    /// assert!(checked.data_part_ascii_no_checksum().iter().eq(ascii.as_bytes().iter()))
+    /// ```
+    #[inline]
+    pub fn data_part_ascii_no_checksum(&self) -> &[u8] { self.ascii }
+
     /// Returns an iterator that yields the data part of the parsed bech32 encoded string.
     ///
     /// Converts the ASCII bytes representing field elements to the respective field elements, then
@@ -398,8 +436,7 @@ impl<'s> SegwitHrpstring<'s> {
 
         let unchecked = UncheckedHrpstring::new(s)?;
 
-        // TODO: Use accessor function.
-        let data_part = unchecked.data_part_ascii;
+        let data_part = unchecked.data_part_ascii();
 
         if data_part.is_empty() {
             return Err(SegwitHrpstringError::NoData);
@@ -434,8 +471,7 @@ impl<'s> SegwitHrpstring<'s> {
     #[inline]
     pub fn new_bech32(s: &'s str) -> Result<Self, SegwitHrpstringError> {
         let unchecked = UncheckedHrpstring::new(s)?;
-        // TODO: Use accessor function.
-        let data_part = unchecked.data_part_ascii;
+        let data_part = unchecked.data_part_ascii();
 
         // Unwrap ok since check_characters (in `Self::new`) checked the bech32-ness of this char.
         let witness_version = Fe32::from_char(data_part[0].into()).unwrap();
@@ -462,6 +498,25 @@ impl<'s> SegwitHrpstring<'s> {
     /// Returns the witness version.
     #[inline]
     pub fn witness_version(&self) -> Fe32 { self.witness_version }
+
+    /// Returns a partial slice of the data part, as ASCII bytes, everything after the witness
+    /// version and before the checksum.
+    ///
+    /// The byte values are guaranteed to be valid bech32 characters.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bech32::{Bech32, primitives::decode::SegwitHrpstring};
+    ///
+    /// let addr = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq";
+    /// let ascii = "ar0srrr7xfkvy5l643lydnw9re59gtzz";
+    ///
+    /// let segwit = SegwitHrpstring::new(&addr).unwrap();
+    /// assert!(segwit.data_part_ascii_no_witver_no_checksum().iter().eq(ascii.as_bytes().iter()))
+    /// ```
+    #[inline]
+    pub fn data_part_ascii_no_witver_no_checksum(&self) -> &[u8] { self.ascii }
 
     /// Returns an iterator that yields the data part, excluding the witness version, of the parsed
     /// bech32 encoded string.

--- a/src/primitives/decode.rs
+++ b/src/primitives/decode.rs
@@ -164,6 +164,33 @@ impl<'s> UncheckedHrpstring<'s> {
     #[inline]
     pub fn data_part_ascii(&self) -> &[u8] { self.data_part_ascii }
 
+    /// Attempts to remove the first byte of the data part, treating it as a witness version.
+    ///
+    /// If [`Self::witness_version`] succeeds this function removes the first character (witness
+    /// version byte) from the internal ASCII data part buffer. Future calls to
+    /// [`Self::data_part_ascii`] will no longer include it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bech32::{primitives::decode::UncheckedHrpstring, Fe32};
+    ///
+    /// let addr = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq";
+    /// let ascii = "ar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq";
+    ///
+    /// let mut unchecked = UncheckedHrpstring::new(&addr).unwrap();
+    /// let witness_version = unchecked.remove_witness_version().unwrap();
+    /// assert_eq!(witness_version, Fe32::Q);
+    /// assert!(unchecked.data_part_ascii().iter().eq(ascii.as_bytes().iter()))
+    /// ```
+    #[inline]
+    pub fn remove_witness_version(&mut self) -> Option<Fe32> {
+        self.witness_version().map(|witver| {
+            self.data_part_ascii = &self.data_part_ascii[1..]; // Remove the witness version byte.
+            witver
+        })
+    }
+
     /// Returns the segwit witness version if there is one.
     ///
     /// Attempts to convert the first character of the data part to a witness version. If this

--- a/src/primitives/decode.rs
+++ b/src/primitives/decode.rs
@@ -164,6 +164,39 @@ impl<'s> UncheckedHrpstring<'s> {
     #[inline]
     pub fn data_part_ascii(&self) -> &[u8] { self.data_part_ascii }
 
+    /// Returns the segwit witness version if there is one.
+    ///
+    /// Attempts to convert the first character of the data part to a witness version. If this
+    /// succeeds, and it is a valid version (0..16 inclusive) we return it, otherwise `None`.
+    ///
+    /// This function makes no guarantees on the validity of the checksum.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bech32::{primitives::decode::UncheckedHrpstring, Fe32};
+    ///
+    /// // Note the invalid checksum!
+    /// let addr = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzffffff";
+    ///
+    /// let unchecked = UncheckedHrpstring::new(&addr).unwrap();
+    /// assert_eq!(unchecked.witness_version(), Some(Fe32::Q));
+    /// ```
+    #[inline]
+    pub fn witness_version(&self) -> Option<Fe32> {
+        let data_part = self.data_part_ascii();
+        if data_part.is_empty() {
+            return None;
+        }
+
+        // unwrap ok because we know we gave valid bech32 characters.
+        let witness_version = Fe32::from_char(data_part[0].into()).unwrap();
+        if witness_version.to_u8() > 16 {
+            return None;
+        }
+        Some(witness_version)
+    }
+
     /// Validates that data has a valid checksum for the `Ck` algorithm and returns a [`CheckedHrpstring`].
     #[inline]
     pub fn validate_and_remove_checksum<Ck: Checksum>(


### PR DESCRIPTION
This is a sexy little PR right here.

Add an `ascii` accessor method to the `UncheckedHrpstring` and `CheckedHrpstring` types. 

- Patch 1 is preparation, renames the `data` field.
- Patch 2 is the meat and potatoes.

Fix: #160 