### PR TITLE
Bump version to 0.10.0-beta2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.10.0-beta2 - 2024-01-16
+
+- Add accessor functions to the `decode` types [167](https://github.com/rust-bitcoin/rust-bech32/pull/167)
+
 # 0.10.0-beta
 
 Re-implement the crate level API using the new `primitives` module.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bech32"
-version = "0.10.0-beta"
+version = "0.10.0-beta2"
 authors = ["Clark Moody", "Andrew Poelstra", "Tobin Harding"]
 repository = "https://github.com/rust-bitcoin/rust-bech32"
 documentation = "https://docs.rs/bech32/"


### PR DESCRIPTION
In preparation for doing another beta release add a changelog entry and bump the version.