### PR TITLE
Use 0.10.0-beta.2 for the upcoming release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.10.0-beta2 - 2024-01-16
+# 0.10.0-beta.2 - 2024-01-17
 
 - Add accessor functions to the `decode` types [167](https://github.com/rust-bitcoin/rust-bech32/pull/167)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bech32"
-version = "0.10.0-beta2"
+version = "0.10.0-beta.2"
 authors = ["Clark Moody", "Andrew Poelstra", "Tobin Harding"]
 repository = "https://github.com/rust-bitcoin/rust-bech32"
 documentation = "https://docs.rs/bech32/"


### PR DESCRIPTION
We just bumped the version number to `0.10.0-beta2` but that format causes `cargo` to automatically pull the new version. We can use `0.10.1-beta.2` so `cargo` correctly treats it as a new separate version.
 
