### PR TITLE
Add witness_version functions to `CheckedHrpstring`

### DIFF
--- a/src/primitives/decode.rs
+++ b/src/primitives/decode.rs
@@ -196,6 +196,9 @@ impl<'s> UncheckedHrpstring<'s> {
     /// Attempts to convert the first character of the data part to a witness version. If this
     /// succeeds, and it is a valid version (0..16 inclusive) we return it, otherwise `None`.
     ///
+    /// Future calls to [`Self::data_part_ascii`] will still include the witness version, use
+    /// [`Self::remove_witness_version`] to remove it.
+    ///
     /// This function makes no guarantees on the validity of the checksum.
     ///
     /// # Examples


### PR DESCRIPTION
As we did for `UncheckedHrpstring` add functions to the `CheckedHrpstring` struct to allow checking the initial byte of the data part and removing it if required.

Add an initial patch that improves the docs on the `UncheckedHrpstring::remove_witness_version` function (this is then copied in patch 2).