### PR TITLE
Fix feature gating

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //!
 //! - If you are doing segwit stuff you likely want to use the [`segwit`] API.
 //! - Non-segwit stuff and you have an allocator, use the top level API. For normal usage the
-//!   [`encode`] and [`decode`] functions should suffice. There are also various other functions for
+//!   `encode` and `decode` functions should suffice. There are also various other functions for
 //!   explicit control of the checksum algorithm and the case used when encoding.
 //! - Non-segwit stuff and you do *not* have an allocator, use the [`CheckedHrpstring`] type for
 //!   decoding. For encoding we provide various top level functions of the form `encode*_to_fmt`.

--- a/src/primitives/hrp.rs
+++ b/src/primitives/hrp.rs
@@ -221,7 +221,7 @@ impl Hrp {
 /// Displays the human-readable part.
 ///
 /// If an uppercase HRP was parsed during object construction then the returned string will be
-/// in uppercase also. For a lowercase string see [`Self::to_lowercase`].
+/// in uppercase also. For a lowercase string see `Self::to_lowercase`.
 impl fmt::Display for Hrp {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for c in self.char_iter() {

--- a/src/segwit.rs
+++ b/src/segwit.rs
@@ -374,6 +374,7 @@ impl From<SegwitHrpstringError> for DecodeError {
 /// An error while constructing a [`SegwitHrpstring`] type.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
+#[cfg(feature = "alloc")]
 pub enum EncodeError {
     /// Invalid witness version (must be 0-16 inclusive).
     WitnessVersion(InvalidWitnessVersionError),
@@ -385,6 +386,7 @@ pub enum EncodeError {
     Fmt(fmt::Error),
 }
 
+#[cfg(feature = "alloc")]
 impl fmt::Display for EncodeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use EncodeError::*;
@@ -399,6 +401,7 @@ impl fmt::Display for EncodeError {
 }
 
 #[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl std::error::Error for EncodeError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use EncodeError::*;
@@ -412,21 +415,25 @@ impl std::error::Error for EncodeError {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl From<InvalidWitnessVersionError> for EncodeError {
     #[inline]
     fn from(e: InvalidWitnessVersionError) -> Self { Self::WitnessVersion(e) }
 }
 
+#[cfg(feature = "alloc")]
 impl From<WitnessLengthError> for EncodeError {
     #[inline]
     fn from(e: WitnessLengthError) -> Self { Self::WitnessLength(e) }
 }
 
+#[cfg(feature = "alloc")]
 impl From<SegwitCodeLengthError> for EncodeError {
     #[inline]
     fn from(e: SegwitCodeLengthError) -> Self { Self::TooLong(e) }
 }
 
+#[cfg(feature = "alloc")]
 impl From<fmt::Error> for EncodeError {
     #[inline]
     fn from(e: fmt::Error) -> Self { Self::Fmt(e) }


### PR DESCRIPTION
We have feature gate issues in docs and with an unused error type.

I don't have a good way of including links that are feature build specific in rustdocs so I just used plain old back ticks.
