### PR TITLE
Bump version to 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-# 0.10.0 - 2024-02-22
+# 0.11.0 - 2024-02-23
+
+The `0.10.0` release contains API breaking changes compared to `0.10.0-beta` and because of semver
+rules (which we adhere to) cannot be released with that version number, we had to yank it and re-do
+the release as `0.11.0` - sorry.
+
+# 0.10.0 - 2024-02-22 - yanked
 
 Release the new `primitives` module! This release is a total re-write of the crate - enjoy.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bech32"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Clark Moody", "Andrew Poelstra", "Tobin Harding"]
 repository = "https://github.com/rust-bitcoin/rust-bech32"
 documentation = "https://docs.rs/bech32/"


### PR DESCRIPTION
We really should have remembered this would happen because of all the drama we had in `bitcoinconsensus`, face palm.

Bump the verison and add a changelog entry explaining the yank and re-release for those that don't know.