### PR TITLE
Add Default trait to Fe32 (derived)

### DIFF
--- a/api/all-features.txt
+++ b/api/all-features.txt
@@ -144,6 +144,7 @@ impl core::convert::TryFrom<u16> for bech32::primitives::gf32::Fe32
 impl core::convert::TryFrom<u32> for bech32::primitives::gf32::Fe32
 impl core::convert::TryFrom<u64> for bech32::primitives::gf32::Fe32
 impl core::convert::TryFrom<u8> for bech32::primitives::gf32::Fe32
+impl core::default::Default for bech32::primitives::gf32::Fe32
 impl core::error::Error for bech32::DecodeError
 impl core::error::Error for bech32::EncodeError
 impl core::error::Error for bech32::EncodeIoError
@@ -1009,6 +1010,7 @@ pub fn bech32::primitives::gf32::Fe32::add_assign(&mut self, other: &bech32::pri
 pub fn bech32::primitives::gf32::Fe32::add_assign(&mut self, other: bech32::primitives::gf32::Fe32)
 pub fn bech32::primitives::gf32::Fe32::as_ref(&self) -> &u8
 pub fn bech32::primitives::gf32::Fe32::clone(&self) -> bech32::primitives::gf32::Fe32
+pub fn bech32::primitives::gf32::Fe32::default() -> bech32::primitives::gf32::Fe32
 pub fn bech32::primitives::gf32::Fe32::div(self, other: &bech32::primitives::gf32::Fe32) -> bech32::primitives::gf32::Fe32
 pub fn bech32::primitives::gf32::Fe32::div(self, other: bech32::primitives::gf32::Fe32) -> bech32::primitives::gf32::Fe32
 pub fn bech32::primitives::gf32::Fe32::div_assign(&mut self, other: &bech32::primitives::gf32::Fe32)

--- a/api/alloc-only.txt
+++ b/api/alloc-only.txt
@@ -139,6 +139,7 @@ impl core::convert::TryFrom<u16> for bech32::primitives::gf32::Fe32
 impl core::convert::TryFrom<u32> for bech32::primitives::gf32::Fe32
 impl core::convert::TryFrom<u64> for bech32::primitives::gf32::Fe32
 impl core::convert::TryFrom<u8> for bech32::primitives::gf32::Fe32
+impl core::default::Default for bech32::primitives::gf32::Fe32
 impl core::fmt::Debug for bech32::DecodeError
 impl core::fmt::Debug for bech32::EncodeError
 impl core::fmt::Debug for bech32::primitives::checksum::PackedNull
@@ -961,6 +962,7 @@ pub fn bech32::primitives::gf32::Fe32::add_assign(&mut self, other: &bech32::pri
 pub fn bech32::primitives::gf32::Fe32::add_assign(&mut self, other: bech32::primitives::gf32::Fe32)
 pub fn bech32::primitives::gf32::Fe32::as_ref(&self) -> &u8
 pub fn bech32::primitives::gf32::Fe32::clone(&self) -> bech32::primitives::gf32::Fe32
+pub fn bech32::primitives::gf32::Fe32::default() -> bech32::primitives::gf32::Fe32
 pub fn bech32::primitives::gf32::Fe32::div(self, other: &bech32::primitives::gf32::Fe32) -> bech32::primitives::gf32::Fe32
 pub fn bech32::primitives::gf32::Fe32::div(self, other: bech32::primitives::gf32::Fe32) -> bech32::primitives::gf32::Fe32
 pub fn bech32::primitives::gf32::Fe32::div_assign(&mut self, other: &bech32::primitives::gf32::Fe32)

--- a/api/no-features.txt
+++ b/api/no-features.txt
@@ -121,6 +121,7 @@ impl core::convert::TryFrom<u16> for bech32::primitives::gf32::Fe32
 impl core::convert::TryFrom<u32> for bech32::primitives::gf32::Fe32
 impl core::convert::TryFrom<u64> for bech32::primitives::gf32::Fe32
 impl core::convert::TryFrom<u8> for bech32::primitives::gf32::Fe32
+impl core::default::Default for bech32::primitives::gf32::Fe32
 impl core::fmt::Debug for bech32::EncodeError
 impl core::fmt::Debug for bech32::primitives::checksum::PackedNull
 impl core::fmt::Debug for bech32::primitives::decode::CharError
@@ -892,6 +893,7 @@ pub fn bech32::primitives::gf32::Fe32::add_assign(&mut self, other: &bech32::pri
 pub fn bech32::primitives::gf32::Fe32::add_assign(&mut self, other: bech32::primitives::gf32::Fe32)
 pub fn bech32::primitives::gf32::Fe32::as_ref(&self) -> &u8
 pub fn bech32::primitives::gf32::Fe32::clone(&self) -> bech32::primitives::gf32::Fe32
+pub fn bech32::primitives::gf32::Fe32::default() -> bech32::primitives::gf32::Fe32
 pub fn bech32::primitives::gf32::Fe32::div(self, other: &bech32::primitives::gf32::Fe32) -> bech32::primitives::gf32::Fe32
 pub fn bech32::primitives::gf32::Fe32::div(self, other: bech32::primitives::gf32::Fe32) -> bech32::primitives::gf32::Fe32
 pub fn bech32::primitives::gf32::Fe32::div_assign(&mut self, other: &bech32::primitives::gf32::Fe32)

--- a/src/primitives/gf32.rs
+++ b/src/primitives/gf32.rs
@@ -66,7 +66,7 @@ const CHARS_INV: [i8; 128] = [
 ];
 
 /// An element in GF(32), the finite field containing elements `[0,31]` inclusive.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash)]
 #[repr(transparent)]
 pub struct Fe32(pub(crate) u8);
 
@@ -486,6 +486,12 @@ mod tests {
             let fe = Fe32::from_char(*c).unwrap();
             assert_eq!(fe * Fe32::P, fe) // Fe32::P == Fe32(1)
         }
+    }
+
+    #[test]
+    fn default() {
+        assert_eq!(Fe32::default().to_u8(), 0);
+        assert_eq!(Fe32::default(), Fe32::Q);
     }
 }
 


### PR DESCRIPTION
See #187 .

Add derived `Default` trait to `Fe32`, ~~and `ZERO` constant~~.
Default is trivial to add, but it is useful in some cases.