### PR TITLE
Add Fe32::ZERO const

### DIFF
--- a/api/all-features.txt
+++ b/api/all-features.txt
@@ -755,6 +755,7 @@ pub const bech32::primitives::gf32::Fe32::X: bech32::primitives::gf32::Fe32
 pub const bech32::primitives::gf32::Fe32::Y: bech32::primitives::gf32::Fe32
 pub const bech32::primitives::gf32::Fe32::Z: bech32::primitives::gf32::Fe32
 pub const bech32::primitives::gf32::Fe32::ZERO: Self
+pub const bech32::primitives::gf32::Fe32::ZERO: bech32::primitives::gf32::Fe32
 pub const bech32::primitives::gf32::Fe32::_0: bech32::primitives::gf32::Fe32
 pub const bech32::primitives::gf32::Fe32::_2: bech32::primitives::gf32::Fe32
 pub const bech32::primitives::gf32::Fe32::_3: bech32::primitives::gf32::Fe32

--- a/api/alloc-only.txt
+++ b/api/alloc-only.txt
@@ -724,6 +724,7 @@ pub const bech32::primitives::gf32::Fe32::X: bech32::primitives::gf32::Fe32
 pub const bech32::primitives::gf32::Fe32::Y: bech32::primitives::gf32::Fe32
 pub const bech32::primitives::gf32::Fe32::Z: bech32::primitives::gf32::Fe32
 pub const bech32::primitives::gf32::Fe32::ZERO: Self
+pub const bech32::primitives::gf32::Fe32::ZERO: bech32::primitives::gf32::Fe32
 pub const bech32::primitives::gf32::Fe32::_0: bech32::primitives::gf32::Fe32
 pub const bech32::primitives::gf32::Fe32::_2: bech32::primitives::gf32::Fe32
 pub const bech32::primitives::gf32::Fe32::_3: bech32::primitives::gf32::Fe32

--- a/api/no-features.txt
+++ b/api/no-features.txt
@@ -665,6 +665,7 @@ pub const bech32::primitives::gf32::Fe32::X: bech32::primitives::gf32::Fe32
 pub const bech32::primitives::gf32::Fe32::Y: bech32::primitives::gf32::Fe32
 pub const bech32::primitives::gf32::Fe32::Z: bech32::primitives::gf32::Fe32
 pub const bech32::primitives::gf32::Fe32::ZERO: Self
+pub const bech32::primitives::gf32::Fe32::ZERO: bech32::primitives::gf32::Fe32
 pub const bech32::primitives::gf32::Fe32::_0: bech32::primitives::gf32::Fe32
 pub const bech32::primitives::gf32::Fe32::_2: bech32::primitives::gf32::Fe32
 pub const bech32::primitives::gf32::Fe32::_3: bech32::primitives::gf32::Fe32

--- a/src/primitives/checksum.rs
+++ b/src/primitives/checksum.rs
@@ -463,7 +463,7 @@ impl<'hrp> Iterator for HrpFe32Iter<'hrp> {
                 Some(high) => return Some(Fe32(high >> 5)),
                 None => {
                     self.high_iter = None;
-                    return Some(Fe32::Q);
+                    return Some(Fe32::ZERO);
                 }
             }
         }

--- a/src/primitives/gf32.rs
+++ b/src/primitives/gf32.rs
@@ -71,6 +71,9 @@ const CHARS_INV: [i8; 128] = [
 pub struct Fe32(pub(crate) u8);
 
 impl Fe32 {
+    /// The Zero element is 0 numeric (character 'Q')
+    pub const ZERO: Fe32 = Fe32(0);
+
     // These are a little gratuitous for a reference implementation, but it makes me happy to do it.
     /// Numeric value maps to bech32 character: 0 == "q".
     pub const Q: Fe32 = Fe32(0);
@@ -257,7 +260,7 @@ impl AsRef<u8> for Fe32 {
 }
 
 impl super::Field for Fe32 {
-    const ZERO: Self = Fe32::Q;
+    const ZERO: Self = Fe32::ZERO;
     const ONE: Self = Fe32::P;
     const GENERATOR: Self = Fe32::Z;
     const MULTIPLICATIVE_ORDER: usize = 31;
@@ -486,6 +489,12 @@ mod tests {
             let fe = Fe32::from_char(*c).unwrap();
             assert_eq!(fe * Fe32::P, fe) // Fe32::P == Fe32(1)
         }
+    }
+
+    #[test]
+    fn const_zero() {
+        assert_eq!(Fe32::ZERO.to_u8(), 0);
+        assert_eq!(Fe32::ZERO.to_char(), 'q');
     }
 }
 


### PR DESCRIPTION
Add `Fe32::ZERO` const, which is the same as `Fe32::Q`, but with more intuitive name.
Also replace `Fe32::Q` to `Fe32::ZERO` in a few relevant places.