### PR TITLE
Add optional dependency on ordering crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,8 @@ alloc = []
 [target.'cfg(mutate)'.dev-dependencies]
 mutagen = { git = "https://github.com/llogiq/mutagen" }
 
+[dependencies]
+ordered = { version = "0.2.2", optional = true}
+
 [lints.rust]
 unexpected_cfgs = { level = "deny", check-cfg = [ 'cfg(bench)', 'cfg(kani)', 'cfg(mutate)' ] }

--- a/src/primitives/gf32.rs
+++ b/src/primitives/gf32.rs
@@ -256,6 +256,12 @@ impl AsRef<u8> for Fe32 {
     fn as_ref(&self) -> &u8 { &self.0 }
 }
 
+/// Field elements do not have a natural order however some users may want to order them.
+#[cfg(feature = "ordered")]
+impl ordered::ArbitraryOrd for Fe32 {
+    fn arbitrary_cmp(&self, other: &Self) -> core::cmp::Ordering { self.0.cmp(&other.0) }
+}
+
 impl super::Field for Fe32 {
     const ZERO: Self = Fe32::Q;
     const ONE: Self = Fe32::P;


### PR DESCRIPTION
Add an optional dependency on the `ordering` crate and implement `ArbitraryOrd` for `Fe32` if the feature is enabled.