### PR TITLE
Remove unused generic

### DIFF
--- a/src/primitives/decode.rs
+++ b/src/primitives/decode.rs
@@ -442,7 +442,7 @@ impl<'s> CheckedHrpstring<'s> {
     ///
     /// Converts the ASCII bytes representing field elements to the respective field elements.
     #[inline]
-    pub fn fe32_iter<I: Iterator<Item = u8>>(&self) -> AsciiToFe32Iter {
+    pub fn fe32_iter(&self, _: u8) -> AsciiToFe32Iter {
         AsciiToFe32Iter { iter: self.ascii.iter().copied() }
     }
 


### PR DESCRIPTION
Turns out `clippy` does not warn for unused generics.
    
Fix: #191
