### PR TITLE
hrp: small improvement in hrp parsing

### DIFF
--- a/src/primitives/hrp.rs
+++ b/src/primitives/hrp.rs
@@ -78,14 +78,14 @@ impl Hrp {
     pub fn parse(hrp: &str) -> Result<Self, Error> {
         use Error::*;
 
-        let mut new = Hrp { buf: [0_u8; MAX_HRP_LEN], size: 0 };
-
         if hrp.is_empty() {
             return Err(Empty);
         }
         if hrp.len() > MAX_HRP_LEN {
             return Err(TooLong(hrp.len()));
         }
+
+        let mut new = Hrp { buf: [0_u8; MAX_HRP_LEN], size: 0 };
 
         let mut has_lower: bool = false;
         let mut has_upper: bool = false;


### PR DESCRIPTION
In the HRP parsing function, we first test the following conditions with potential error outputs:

```rust
if hrp.is_empty() {
    return Err(Empty);
}
if hrp.len() > MAX_HRP_LEN {
    return Err(TooLong(hrp.len()));
}
```

So we don't need to directly declare the `new` variable in case an error is thrown and this declaration becoming useless. We can wait for the checks to be ok before declaring this (very small improvement).