### PR TITLE
fix: typos in documentation files

### DIFF
--- a/embedded/README.md
+++ b/embedded/README.md
@@ -1,11 +1,11 @@
 ## Embedded tests
 
 These no-std tests are a bit peculiar.
-They are cross compiled to ARM and run in an emulator.
+They are cross-compiled to ARM and run in an emulator.
 Here's why:
 
  - We want to build for an exotic platform to help make sure `std` doesn't sneak in by accident.
 
  - We use an emulator and build something runnable,
    rather than merely testing whether a library builds,
-   because we want to actually run our integration test.
+   because we want to actually run our integration tests.


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

Description correction:
Corrected `cross compiled` to `cross-compiled`
Corrected `integration test` to `integration tests`

Please review the changes and let me know if any additional changes are needed.