### PR TITLE
chore: fix cargo clippy warning

### DIFF
--- a/src/primitives/decode.rs
+++ b/src/primitives/decode.rs
@@ -135,7 +135,7 @@ impl<'s> UncheckedHrpstring<'s> {
 
         let ret = UncheckedHrpstring {
             hrp: Hrp::parse(hrp)?,
-            data_part_ascii: rest[1..].as_bytes(), // Skip the separator.
+            data_part_ascii: &rest.as_bytes()[1..], // Skip the separator.
             hrpstring_length: s.len(),
         };
 


### PR DESCRIPTION
Running cargo clippy reports the following error.

```shell
warning: calling `as_bytes` after slicing a string
   --> src/primitives/decode.rs:138:30
    |
138 |             data_part_ascii: rest[1..].as_bytes(), // Skip the separator.
    |                              ^^^^^^^^^^^^^^^^^^^^ help: try: `&rest.as_bytes()[1..]`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#sliced_string_as_bytes
    = note: `#[warn(clippy::sliced_string_as_bytes)]` on by default
```

This commit resolves the issue.

