### PR TITLE
Manual daily update to rustc (to nightly-2026-08-28)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 rust-version = "1.56.1"
 
 [package.metadata.rbmt.toolchains]
-nightly = "nightly-2026-08-20"
+nightly = "nightly-2026-08-28"
 stable = "stable"
 
 [features]

--- a/src/primitives/gf32_ext.rs
+++ b/src/primitives/gf32_ext.rs
@@ -103,8 +103,8 @@ where
             self.inner[i + 1] = self.inner[i];
         }
         self.inner[0] = Fe32::Q;
-        for i in 0..DEG {
-            self.inner[i] += xn_coeff * Self::POLYNOMIAL.inner[i]
+        for (i, elem) in self.inner.iter_mut().enumerate() {
+            *elem += xn_coeff * Self::POLYNOMIAL.inner[i]
         }
     }
 


### PR DESCRIPTION
Supersedes https://github.com/rust-bitcoin/rust-bech32/pull/298

Fixes a lint error about loop using index instead of enum in primitives. 